### PR TITLE
[ACM-9992][ACM-9994] Added automountServiceAccountToken field to constructed deployment resource

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+# Description
+
+Please provide a brief description of the purpose of this pull request.
+
+## Related Issue
+
+If applicable, please reference the issue(s) that this pull request addresses.
+
+## Changes Made
+
+Provide a clear and concise overview of the changes made in this pull request.
+
+## Screenshots (if applicable)
+
+Add screenshots or GIFs that demonstrate the changes visually, if relevant.
+
+## Checklist
+
+- [ ] I have tested the changes locally and they are functioning as expected.
+- [ ] I have updated the documentation (if necessary) to reflect the changes.
+- [ ] I have added/updated relevant unit tests (if applicable).
+- [ ] I have ensured that my code follows the project's coding standards.
+- [ ] I have checked for any potential security issues and addressed them.
+- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
+- [ ] I have rebased my branch on top of the latest main/master branch.
+
+## Additional Notes
+
+Add any additional notes, context, or information that might be helpful for reviewers.
+
+## Reviewers
+
+Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`
+
+## Definition of Done
+
+- [ ] Code is reviewed.
+- [ ] Code is tested.
+- [ ] Documentation is updated.
+- [ ] All checks and tests pass.
+- [ ] Approved by at least one reviewer.
+- [ ] Merged into the main/master branch.

--- a/bundle-generation/generate-bundles.py
+++ b/bundle-generation/generate-bundles.py
@@ -505,11 +505,15 @@ def updateDeployments(helmChart, exclusions):
         pod_template_spec['hostNetwork'] = False
         pod_template_spec['hostPID'] = False
         pod_template_spec['hostIPC'] = False
+        
+        if 'automountServiceAccountToken' not in pod_template_spec:
+            pod_template_spec['automountServiceAccountToken'] = True
 
         if 'securityContext' not in pod_template_spec:
             pod_template_spec['securityContext'] = {}
         pod_security_context = pod_template_spec['securityContext']
         pod_security_context['runAsNonRoot'] = True
+
         if 'seccompProfile' not in pod_security_context:
             pod_security_context['seccompProfile'] = {'type': 'RuntimeDefault'}
             # This will be made conditional on OCP version >= 4.11 by injectHelmFlowControl()
@@ -522,9 +526,6 @@ def updateDeployments(helmChart, exclusions):
 
         containers = pod_template_spec['containers']
         for container in containers:
-            if 'automountServiceAccountToken' not in container:
-                container['automountServiceAccountToken'] = True
-
             if 'env' not in container:
                 container['env'] = {}
 

--- a/bundle-generation/generate-bundles.py
+++ b/bundle-generation/generate-bundles.py
@@ -522,6 +522,9 @@ def updateDeployments(helmChart, exclusions):
 
         containers = pod_template_spec['containers']
         for container in containers:
+            if 'automountServiceAccountToken' not in container:
+                container['automountServiceAccountToken'] = True
+
             if 'env' not in container:
                 container['env'] = {}
 


### PR DESCRIPTION
This PR will update the `bundle-automation` script to begin adding the `automountServiceAccountToken` field to deployments that the MCH and MCE operator is responsible for deploying.

Related Jiras:
- https://issues.redhat.com/browse/ACM-9992
- https://issues.redhat.com/browse/ACM-9994

/cc @cameronmwall @ngraham20 