### PR TITLE
[ACM-9992] Add support for automountServiceAccountToken injection for operator configurations

### DIFF
--- a/bundle-generation/generate-bundles.py
+++ b/bundle-generation/generate-bundles.py
@@ -558,7 +558,11 @@ def updateDeployments(helmChart, operator, exclusions, sizes):
         
         # Set automountServiceAccountToken only if is configured for the operator.
         if 'automountServiceAccountToken' in operator:
-            pod_template_spec['automountServiceAccountToken'] = operator.get('automountServiceAccountToken')
+            automountSAToken = operator.get('automountServiceAccountToken')
+            if isinstance(automountSAToken, bool):
+                pod_template_spec['automountServiceAccountToken'] = operator.get('automountServiceAccountToken')
+            else:
+                logging.warning("automountServiceAccountToken should be a boolean. Ignoring invalid value.")
 
         if 'securityContext' not in pod_template_spec:
             pod_template_spec['securityContext'] = {}

--- a/bundle-generation/generate-bundles.py
+++ b/bundle-generation/generate-bundles.py
@@ -523,7 +523,7 @@ def injectHelmFlowControl(deployment, sizes):
     logging.info("Added Helm flow control for NodeSelector, Proxy Overrides and SecCompProfile.\n")
 
 # updateDeployments adds standard configuration to the deployments (antiaffinity, security policies, and tolerations)
-def updateDeployments(helmChart, exclusions, sizes):
+def updateDeployments(helmChart, operator, exclusions, sizes):
     logging.info("Updating deployments with antiaffinity, security policies, and tolerations ...")
     deploySpecYaml = os.path.join(os.path.dirname(os.path.realpath(__file__)), "chart-templates/templates/deploymentspec.yaml")
     with open(deploySpecYaml, 'r') as f:
@@ -556,8 +556,9 @@ def updateDeployments(helmChart, exclusions, sizes):
         pod_template_spec['hostPID'] = False
         pod_template_spec['hostIPC'] = False
         
-        # if 'automountServiceAccountToken' not in pod_template_spec:
-        #     pod_template_spec['automountServiceAccountToken'] = False
+        # Set automountServiceAccountToken only if is configured for the operator.
+        if 'automountServiceAccountToken' in operator:
+            pod_template_spec['automountServiceAccountToken'] = operator.get('automountServiceAccountToken')
 
         if 'securityContext' not in pod_template_spec:
             pod_template_spec['securityContext'] = {}
@@ -622,12 +623,18 @@ def updateRBAC(helmChart):
     logging.info("Clusterroles, roles, clusterrolebindings, and rolebindings updated. \n")
 
 
-def injectRequirements(helmChart, imageKeyMapping, exclusions, sizes):
+def injectRequirements(helmChart, operator, exclusions, sizes):
     logging.info("Updating Helm chart '%s' with onboarding requirements ...", helmChart)
+    imageKeyMapping = operator.get('imageMappings', {})
+
+    # Fixes image references in the Helm chart.
     fixImageReferences(helmChart, imageKeyMapping)
     fixEnvVarImageReferences(helmChart, imageKeyMapping)
+
+    # Updates RBAC and deployment configuration in the Helm chart.
     updateRBAC(helmChart)
-    updateDeployments(helmChart, exclusions, sizes)
+    updateDeployments(helmChart, operator, exclusions, sizes)
+
     logging.info("Updated Chart '%s' successfully\n", helmChart)
 
 def addCMAs(repo, operator, outputDir):
@@ -969,7 +976,7 @@ def main():
             if not skipOverrides:
                 logging.info("Adding Overrides to helm chart '%s' (set --skipOverrides=true to skip) ...", operator["name"])
                 exclusions = operator["exclusions"] if "exclusions" in operator else []
-                injectRequirements(helmChart, operator["imageMappings"], exclusions, sizes)
+                injectRequirements(helmChart, operator, exclusions, sizes)
                 logging.info("Overrides added to helm chart '%s' successfully.", operator["name"])
 
     logging.info("All repositories and operators processed successfully.")


### PR DESCRIPTION
# Description

To reduce the amount of code smells that are repositories have, one of them is to ensure that the `automountServiceAccountToken` is set to `false`. Though we do not want to do that, it would be a good idea for to inject it into the deployment if a component requires it.

## Related Issue

https://issues.redhat.com/browse/ACM-9992

## Changes Made

Injects `automountServiceAccountToken` if the field is set within the operator's config.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
