### PR TITLE
[ACM-19713] Fixed envvar data type from object to array

### DIFF
--- a/bundle-generation/bundles-to-charts.py
+++ b/bundle-generation/bundles-to-charts.py
@@ -1101,8 +1101,8 @@ def inject_security_context_constraints(resource, constraints_override):
         container_name = container.get('name')
         container_security_context = container.setdefault('securityContext', {})
 
-        # Set container env to empty map, if it doesn't exist.
-        container.setdefault('env', {})
+        # Set container env to empty array, if it doesn't exist.
+        container.setdefault('env', [])
 
         # Find matching constraint by container name
         matching_constraint = next((c for c in container_constraints_override if c.get('name') == container_name), {})

--- a/bundle-generation/generate-charts.py
+++ b/bundle-generation/generate-charts.py
@@ -1052,8 +1052,8 @@ def inject_security_context_constraints(resource, constraints_override):
         container_name = container.get('name')
         container_security_context = container.setdefault('securityContext', {})
 
-        # Set container env to empty map, if it doesn't exist.
-        container.setdefault('env', {})
+        # Set container env to empty array, if it doesn't exist.
+        container.setdefault('env', [])
 
         # Find matching constraint by container name
         matching_constraint = next((c for c in container_constraints_override if c.get('name') == container_name), {})


### PR DESCRIPTION
# Description

During testing of ACM 2.13.3, we found that the `env` field in the container spec of the resource template was being set incorrectly as an `object`. This PR updates the field to use the correct data type, changing it to an `array`.

## Related Issue

https://issues.redhat.com/browse/ACM-19713

## Changes Made

Modified the automation scripts to default the `env` field to an `array` if it is not already defined in the resource.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
