### PR TITLE
Remove Z from end of timestamp

### DIFF
--- a/scripts/konflux/compliance.sh
+++ b/scripts/konflux/compliance.sh
@@ -93,7 +93,7 @@ check_promoted() {
             # inspection failed
             buildtime="INSPECTION_FAILURE,Failed"
         else
-            buildtime="$(echo "$skopeo" | yq -p=json ".Labels.build-date"),Successful"
+            buildtime="$(echo "$skopeo" | yq -p=json ".Labels.build-date" | sed 's/Z$//'),Successful"
         fi
     else
         # invalid or incomplete digest

--- a/scripts/konflux/compliance.sh
+++ b/scripts/konflux/compliance.sh
@@ -290,6 +290,21 @@ check_multiarch_support() {
     fi
 }
 
+# Function to check if component is a bundle operator
+check_bundle_operator() {
+    local component="$1"
+    
+    # Check if component starts with "mce-operator-bundle" or "acm-operator-bundle"
+    if [[ "$component" == mce-operator-bundle* || "$component" == acm-operator-bundle* ]]; then
+        echo "🟡 $component Bundle Operator: TRUE" >&3
+        echo "🟡 $component Hermetic: Not Applicable" >&3
+        echo "🟡 $component Multiarch: Not Applicable" >&3
+        echo "BUNDLE_OPERATOR"
+    else
+        echo "REGULAR_COMPONENT"
+    fi
+}
+
 if [[ -n "$debug" && "$debug" != "true" ]]; then
     components=$debug
 else
@@ -325,7 +340,15 @@ for line in $components; do
     pull_yaml="${pull_yaml%???}"
     [[ -n "$debug" && "$http_code_pull" == "404" ]] && echo -e "[debug] \033[31m404 error\033[0m fetching pull YAML from $pull" >&3
 
-    data="$data,$(check_hermetic_builds "$yaml" "$pull_yaml" "$authorization" "$org" "$repo")"
+    # Check if component is a bundle operator
+    bundle_result=$(check_bundle_operator "$line")
+    
+    # Check hermetic builds (skip for bundle operators)
+    if [[ "$bundle_result" == "BUNDLE_OPERATOR" ]]; then
+        data="$data,Not Applicable"
+    else
+        data="$data,$(check_hermetic_builds "$yaml" "$pull_yaml" "$authorization" "$org" "$repo")"
+    fi
 
     # Check enterprise contract
     ec_result=$(check_enterprise_contract "$application" "$line" "$authorization" "$org" "$repo" "$branch")
@@ -342,7 +365,12 @@ for line in $components; do
     
     data="$data,$ec_result"
 
-    data="$data,$(check_multiarch_support "$yaml" "$repo")"
+    # Check multiarch support (skip for bundle operators)
+    if [[ "$bundle_result" == "BUNDLE_OPERATOR" ]]; then
+        data="$data,Not Applicable"
+    else
+        data="$data,$(check_multiarch_support "$yaml" "$repo")"
+    fi
 
     echo ""
 


### PR DESCRIPTION
the Z means UTC instead of local time (probably EST), so some of these images may be a few hours off, but that's not too much of an issue

also make acm and mce operator bundles "Not Applicable" for hermetic and multi-arch

# Description

Please provide a brief description of the purpose of this pull request.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
