### PR TITLE
Fix multi document yaml addontemplate

### DIFF
--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -1052,7 +1052,7 @@ def updateDeployments(helmChart, operator, exclusions, sizes, branch):
     deploySpecYaml = os.path.join(os.path.dirname(os.path.realpath(__file__)), "chart-templates/templates/deploymentspec.yaml")
     with open(deploySpecYaml, 'r', encoding='utf-8') as f:
         deploySpec = yaml.safe_load(f)
-    deployments = find_templates_of_type(helmChart, 'Deployment')
+    deployments = find_templates_of_type(helmChart, 'Deployment', branch)
     for deployment in deployments:
         with open(deployment, 'r', encoding='utf-8') as f:
             deploy = yaml.safe_load(f)

--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -917,10 +917,10 @@ def is_version_compatible(branch, min_release_version, min_backplane_version, mi
             logging.error("Version not found in branch: %s", branch)
             return False
         
-    if acm_release_version and acm_release_version >= min_release_version:
+    if acm_release_version and version.Version(acm_release_version) >= version.Version(min_release_version):
         return True
 
-    elif mce_release_version and mce_release_version >= min_backplane_version:
+    elif mce_release_version and version.Version(mce_release_version) >= version.Version(min_backplane_version):
         return True
 
     else:

--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -1267,16 +1267,20 @@ def addCRDs(repo, operator, outputDir, preservedFiles=None, overwrite=False):
 
         filepath = os.path.join(manifestsPath, filename)
         with open(filepath, 'r', encoding='utf-8') as f:
-            resourceFile = yaml.safe_load(f)
+            # Handle both single and multi-document YAML files
+            docs = list(yaml.safe_load_all(f))
 
-        if "kind" not in resourceFile:
-            continue
+        # Check each document for CRDs
+        for doc in docs:
+            if not doc or "kind" not in doc:
+                continue
 
-        elif resourceFile["kind"] == "CustomResourceDefinition":
-            dest_file_path = os.path.join(outputDir, "crds", operator['name'], filename)
-            if overwrite or not os.path.exists(dest_file_path):
-                shutil.copyfile(filepath, dest_file_path)
-                logging.info("CRD file copied: %s", filename)
+            if doc["kind"] == "CustomResourceDefinition":
+                dest_file_path = os.path.join(outputDir, "crds", operator['name'], filename)
+                if overwrite or not os.path.exists(dest_file_path):
+                    shutil.copyfile(filepath, dest_file_path)
+                    logging.info("CRD file copied: %s", filename)
+                break  # Only copy the file once even if it has multiple CRDs
 
     logging.info("CRDs added successfully for operator: %s", operator['name'])
 

--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -1352,13 +1352,16 @@ def get_csv_path(repo, operator):
 
         file_path = os.path.join(manifests_path, file_name)
         with open(file_path, 'r', encoding='utf-8') as f:
-            resource_file = yaml.safe_load(f)
+            # Handle both single and multi-document YAML files
+            docs = list(yaml.safe_load_all(f))
 
-        if resource_file and resource_file.get("kind") == "ClusterServiceVersion":
-            logging.info("CSV file found: %s", file_path)
-            return file_path
+        # Check if any document in the file is a ClusterServiceVersion
+        for doc in docs:
+            if doc and doc.get("kind") == "ClusterServiceVersion":
+                logging.info("CSV file found: %s", file_path)
+                return file_path
 
-    logging.warning("No CSV file found in directory: %s", resource_file)
+    logging.warning("No CSV file found in directory: %s", manifests_path)
     return None
 
 # injectAnnotationsForAddonTemplate injects following annotations for deployments in the AddonTemplate:


### PR DESCRIPTION
# Description

The original script couldn't properly handle multi-document YAML files (files containing multiple resources separated by `---`). When bundles contained files like
  gitops-addon.addonTemplates.yaml with multiple AddOnTemplate resources, they were copied as-is, creating issues with:
  - Helm chart rendering (multi-resource files in templates/)
  - Conditional logic application (can't selectively enable/disable individual resources)
  - Git diffs (changes to one resource affect the entire file)

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

- Updated copy_additional_resources() to split multi-document YAML files into individual resource files
- Applied same splitting logic to other functions: addCRDs(), get_csv_path(), copy_additional_resources()
- Each resource extracted from bundle gets its own file using pattern: {metadata.name}-{kind}.yaml

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
