### PR TITLE
WIP: Fix deep_update to merge new keys from overwriteValues

### DIFF
--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -267,8 +267,8 @@ def deep_update(overwrite, original):
         if isinstance(value, dict) and key in original and isinstance(original[key], dict):
             # If both the original and overwrite values are dictionaries, recurse into the dictionary
             deep_update(value, original[key])
-        elif key in original:
-            # Otherwise, directly replace the value
+        else:
+            # Otherwise, directly replace or add the value (even if key doesn't exist in original)
             original[key] = value
 
 


### PR DESCRIPTION
## Summary
This PR fixes a bug in the `deep_update` function that prevented new keys from being added when merging overwriteValues.yaml with the original chart values.yaml.

## Problem
The `deep_update` function only updated keys that already existed in the original values.yaml file:
```python
elif key in original:  # Only updates existing keys!
    original[key] = value
```

This meant that new keys in overwriteValues.yaml (like `addOnTemplateName`) were never added to the chart's values, causing the overwrite values to be partially ignored.

## Solution
Changed the condition from `elif key in original` to `else` to allow new keys to be added:
```python
else:  # Add new keys even if they don't exist in original
    original[key] = value
```

## Impact
This fixes issues where users specify custom values in overwriteValues.yaml but those values don't get applied if the keys don't already exist in the upstream chart's values.yaml.

### Specific Use Case
For managed-serviceaccount, the upstream chart has `addOnTemplateName` commented out. Users want to set this value in overwriteValues.yaml to control the AddOnTemplate resource name, but it was being ignored, resulting in versioned names like `managed-serviceaccount-2.17` instead of the desired `managed-serviceaccount`.

## Testing
- [x] Manually tested with managed-serviceaccount chart
- [x] Verified that overwriteValues.yaml keys are now properly merged

## Related Issue
Fixes https://issues.redhat.com/browse/ACM-30000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart generation data processing to correctly handle and incorporate all configuration values, ensuring no data is lost when merging from multiple sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->