### PR TITLE
get-vcs-refs.sh: Allow overriding yq

### DIFF
--- a/scripts/hive/get-vcs-refs.sh
+++ b/scripts/hive/get-vcs-refs.sh
@@ -33,7 +33,8 @@ Examples:
 
 Requirements:
     - Logged into registry.redhat.io (run: podman login registry.redhat.io)
-    - podman, yq, and skopeo must be installed
+    - podman, yq v4, and skopeo must be installed
+    - You may override your default yq by setting the \$YQ env var
 EOF
     exit 0
 }
@@ -75,15 +76,16 @@ TMP_DIR=$(mktemp -d)
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
 # Check yq version (must be v4+)
-if ! command -v yq &>/dev/null; then
+YQ=${YQ:-yq}
+if ! command -v -- "$YQ" &>/dev/null; then
     echo -e "${RED}❌ Error: yq is not installed${RESET}" >&2
     exit 1
 fi
 
-yq_version=$(yq --version 2>&1 | grep -oP 'version\s+v?\K[0-9]+' | head -1)
+yq_version=$("$YQ" --version 2>&1 | grep -oP 'version\s+v?\K[0-9]+' | head -1)
 if [[ -z "$yq_version" ]] || [[ "$yq_version" -lt 4 ]]; then
     echo -e "${RED}❌ Error: yq version 4 or higher is required${RESET}" >&2
-    echo -e "${YELLOW}💡 Current version: $(yq --version 2>&1)${RESET}" >&2
+    echo -e "${YELLOW}💡 Current version: $("$YQ" --version 2>&1)${RESET}" >&2
     exit 1
 fi
 
@@ -117,7 +119,7 @@ if [[ ! -f "$csv_file" ]]; then
 fi
 
 # Extract the hive image from the CSV
-image=$(yq '.spec.relatedImages[] | select(.name == "openshift_hive") | .image' "$csv_file" 2>/dev/null)
+image=$("$YQ" '.spec.relatedImages[] | select(.name == "openshift_hive") | .image' "$csv_file" 2>/dev/null)
 
 if [[ -z "$image" ]]; then
     log "${RED}❌ No hive image found in bundle${RESET}"


### PR DESCRIPTION
Since yq v3 and v4 are not compatible
and get-vcs-refs.sh expects v4
and lots of people still use v3 by default
allow setting a `$YQ` environment variable to override whatever `command -v yq` would otherwise turn up.

```
$ ./scripts/hive/get-vcs-refs.sh v2.10.1
❌ Error: yq version 4 or higher is required
💡 Current version: yq version 3.3.2
$ YQ=yq-v4.47.1 ./scripts/hive/get-vcs-refs.sh v2.10.1
🔍 Fetching bundle v2.10.1
✓ Bundle extracted
🔎 Parsing ClusterServiceVersion
✓ Found hive image

📦 Hive Image VCS Reference

bundle: v2.10.1
image: registry.redhat.io/multicluster-engine/hive-rhel9@sha256:0b67b05f4f550d2f77f0ce5a3bc87dc975395bf161e7a7dcc9ea38a115b5f8eb
sha: dafa2293d6f6e3601e16d2a7e7b33d089c5e2da3

✨ Done!
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build/install scripts now allow configuring which YAML processor binary is used via an environment variable, enabling custom tool selection.
  * Installation/help messages updated to require yq v4 and to document how to override the default YAML tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->