### PR TITLE
Add default probe timeouts to prevent failures on slow I/O

### DIFF
--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -1074,52 +1074,125 @@ def injectHelmFlowControl(deployment, sizes, branch):
     a_file.close()
     logging.info("Added Helm flow control for NodeSelector, Proxy Overrides and SecCompProfile.\n")
 
-# add_probe_defaults adds explicit timeout and failure threshold values to probes (ACM 2.17+)
-def add_probe_defaults(deployment):
+# inject_probe_config_helm_templates injects conditional probeConfig templates (ACM 2.17+)
+def inject_probe_config_helm_templates(deployment_file):
     """
-    Adds default timeoutSeconds and failureThreshold to probes that don't have them.
-    Only applies to exec probes (like 'ls' commands) which are more susceptible to I/O delays.
+    Injects conditional Helm templates for probe configuration into deployment files.
+
+    Adds template blocks for exec probes that allow users to optionally configure:
+    - timeoutSeconds (K8s default: 1)
+    - failureThreshold (K8s default: 3)
+    - successThreshold (K8s default: 1)
 
     This addresses ACM-29011 where customers on compact clusters or slow I/O systems
-    experience frequent probe timeouts with the Kubernetes default of 1 second.
+    experience frequent probe timeouts. Rather than forcing new defaults on all users,
+    this allows opt-in configuration via MCH CR probeConfig field while preserving
+    Kubernetes defaults when not configured.
+
+    Only applies to exec probes (not httpGet/tcpSocket). Only injects if values don't
+    already exist in the template.
 
     Note: This function is only called for ACM 2.17+ and MCE 2.17+ releases.
 
     Args:
-        deployment (dict): The deployment manifest to update
+        deployment_file (str): Path to the deployment YAML file to update
     """
-    def update_single_probe(probe, probe_type, container_name, deployment_name):
-        """Helper to update a single probe with template defaults"""
-        # Only add defaults if it's an exec probe (not httpGet/tcpSocket)
-        if 'exec' not in probe:
-            return False
+    import re
 
-        modified = False
-        if 'timeoutSeconds' not in probe:
-            probe['timeoutSeconds'] = '{{ .Values.hubconfig.probeTimeoutSeconds | default 10 }}'
-            logging.info(f"  Added timeoutSeconds template to {probe_type} in {deployment_name}/{container_name}")
-            modified = True
-        if 'failureThreshold' not in probe:
-            probe['failureThreshold'] = '{{ .Values.hubconfig.probeFailureThreshold | default 3 }}'
-            logging.info(f"  Added failureThreshold template to {probe_type} in {deployment_name}/{container_name}")
-            modified = True
-        return modified
+    with open(deployment_file, 'r', encoding='utf-8') as f:
+        content = f.read()
 
-    deployment_name = deployment.get('metadata', {}).get('name', 'unknown')
-    containers = deployment.get('spec', {}).get('template', {}).get('spec', {}).get('containers', [])
+    lines = content.split('\n')
+    new_lines = []
+    i = 0
 
-    modified = False
-    for container in containers:
-        container_name = container.get('name', 'unknown')
+    while i < len(lines):
+        line = lines[i]
+        new_lines.append(line)
 
-        # Update all probe types (liveness, readiness, startup)
-        for probe_type in ['livenessProbe', 'readinessProbe', 'startupProbe']:
-            if probe_type in container:
-                if update_single_probe(container[probe_type], probe_type, container_name, deployment_name):
-                    modified = True
+        # Detect probe sections (livenessProbe, readinessProbe, startupProbe)
+        probe_match = re.match(r'^(\s+)(livenessProbe|readinessProbe|startupProbe):\s*$', line)
+        if probe_match:
+            probe_indent = len(probe_match.group(1))
+            value_indent = probe_indent + 2
+            indent_str = ' ' * value_indent
 
-    if modified:
-        logging.info(f"Applied probe defaults to deployment '{deployment_name}'")
+            # Look ahead to check if this is an exec probe and what fields exist
+            j = i + 1
+            is_exec_probe = False
+            has_timeout = False
+            has_failure = False
+            has_success = False
+            last_probe_line = i
+
+            while j < len(lines):
+                next_line = lines[j]
+                if next_line.strip():  # Skip empty lines
+                    next_indent = len(next_line) - len(next_line.lstrip())
+
+                    # If indent decreased, we've left the probe section
+                    if next_indent <= probe_indent:
+                        break
+
+                    if next_indent == value_indent:
+                        if 'exec:' in next_line:
+                            is_exec_probe = True
+                        if 'timeoutSeconds:' in next_line:
+                            has_timeout = True
+                        if 'failureThreshold:' in next_line:
+                            has_failure = True
+                        if 'successThreshold:' in next_line:
+                            has_success = True
+                        last_probe_line = j
+
+                new_lines.append(lines[j])
+                j += 1
+
+            # If it's an exec probe and missing fields, inject conditional templates
+            if is_exec_probe:
+                templates_to_add = []
+
+                if not has_timeout:
+                    templates_to_add.extend([
+                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
+                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}}}',
+                        f'{indent_str}timeoutSeconds: {{{{ .Values.hubconfig.probeConfig.timeoutSeconds }}}}',
+                        f'{indent_str[:-2]}{{{{- end }}}}',
+                        f'{indent_str[:-2]}{{{{- end }}}}'
+                    ])
+
+                if not has_failure:
+                    templates_to_add.extend([
+                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
+                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.failureThreshold }}}}',
+                        f'{indent_str}failureThreshold: {{{{ .Values.hubconfig.probeConfig.failureThreshold }}}}',
+                        f'{indent_str[:-2]}{{{{- end }}}}',
+                        f'{indent_str[:-2]}{{{{- end }}}}'
+                    ])
+
+                if not has_success:
+                    templates_to_add.extend([
+                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
+                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.successThreshold }}}}',
+                        f'{indent_str}successThreshold: {{{{ .Values.hubconfig.probeConfig.successThreshold }}}}',
+                        f'{indent_str[:-2]}{{{{- end }}}}',
+                        f'{indent_str[:-2]}{{{{- end }}}}'
+                    ])
+
+                # Insert templates after the last probe field
+                if templates_to_add:
+                    new_lines.extend(templates_to_add)
+                    logging.info(f"  Injected probeConfig templates for {probe_match.group(2)} in {deployment_file}")
+
+            # Skip the lines we already processed
+            i = j
+            continue
+
+        i += 1
+
+    # Write updated content
+    with open(deployment_file, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(new_lines))
 
 # updateDeployments adds standard configuration to the deployments (antiaffinity, security policies, and tolerations)
 def updateDeployments(helmChart, operator, exclusions, sizes, branch):
@@ -1175,10 +1248,6 @@ def updateDeployments(helmChart, operator, exclusions, sizes, branch):
         pod_template_spec['nodeSelector'] = ""
         pod_template_spec['imagePullSecrets'] = ''
 
-        # Add probe defaults to exec probes that don't have explicit timeouts (ACM 2.17+)
-        if is_version_compatible(branch, '2.17', '2.17', '2.17'):
-            add_probe_defaults(deploy)
-
         with open(deployment, 'w', encoding='utf-8') as f:
             yaml.dump(deploy, f, width=float("inf"))
 
@@ -1186,15 +1255,10 @@ def updateDeployments(helmChart, operator, exclusions, sizes, branch):
 
         injectHelmFlowControl(deployment, sizes, branch)
 
-        # Post-process to remove quotes from Helm template expressions for integer values
-        # This must be done AFTER injectHelmFlowControl since that function reads the YAML
-        with open(deployment, 'r', encoding='utf-8') as f:
-            content = f.read()
-        # Remove quotes around template expressions that should be integers (probeTimeoutSeconds, probeFailureThreshold)
-        content = content.replace("'{{ .Values.hubconfig.probeTimeoutSeconds | default 10 }}'", "{{ .Values.hubconfig.probeTimeoutSeconds | default 10 }}")
-        content = content.replace("'{{ .Values.hubconfig.probeFailureThreshold | default 3 }}'", "{{ .Values.hubconfig.probeFailureThreshold | default 3 }}")
-        with open(deployment, 'w', encoding='utf-8') as f:
-            f.write(content)
+        # Inject conditional probe config templates (ACM 2.17+)
+        # This must be done AFTER injectHelmFlowControl since that function manipulates the YAML
+        if is_version_compatible(branch, '2.17', '2.17', '2.17'):
+            inject_probe_config_helm_templates(deployment)
 
 # updateRBAC adds standard configuration to the RBAC resources (clusterroles, roles, clusterrolebindings, and rolebindings)
 def updateRBAC(helmChart, branch):

--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -1128,27 +1128,27 @@ def inject_probe_config_helm_templates(deployment_file):
             if 'exec:' in probe_text:
                 # Append missing fields
                 if 'timeoutSeconds:' not in probe_text:
-                    lines.insert(j, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}\n')
-                    lines.insert(j+1, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}}}\n')
+                    lines.insert(j, '{{- if .Values.hubconfig.probeConfig }}\n')
+                    lines.insert(j+1, '{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}\n')
                     lines.insert(j+2, f'{field_indent}timeoutSeconds: {{{{ .Values.hubconfig.probeConfig.timeoutSeconds }}}}\n')
-                    lines.insert(j+3, f'{field_indent[:-2]}{{{{- end }}}}\n')
-                    lines.insert(j+4, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    lines.insert(j+3, '{{- end }}\n')
+                    lines.insert(j+4, '{{- end }}\n')
                     j += 5
 
                 if 'failureThreshold:' not in probe_text:
-                    lines.insert(j, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}\n')
-                    lines.insert(j+1, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig.failureThreshold }}}}\n')
+                    lines.insert(j, '{{- if .Values.hubconfig.probeConfig }}\n')
+                    lines.insert(j+1, '{{- if .Values.hubconfig.probeConfig.failureThreshold }}\n')
                     lines.insert(j+2, f'{field_indent}failureThreshold: {{{{ .Values.hubconfig.probeConfig.failureThreshold }}}}\n')
-                    lines.insert(j+3, f'{field_indent[:-2]}{{{{- end }}}}\n')
-                    lines.insert(j+4, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    lines.insert(j+3, '{{- end }}\n')
+                    lines.insert(j+4, '{{- end }}\n')
                     j += 5
 
                 if 'successThreshold:' not in probe_text:
-                    lines.insert(j, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}\n')
-                    lines.insert(j+1, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig.successThreshold }}}}\n')
+                    lines.insert(j, '{{- if .Values.hubconfig.probeConfig }}\n')
+                    lines.insert(j+1, '{{- if .Values.hubconfig.probeConfig.successThreshold }}\n')
                     lines.insert(j+2, f'{field_indent}successThreshold: {{{{ .Values.hubconfig.probeConfig.successThreshold }}}}\n')
-                    lines.insert(j+3, f'{field_indent[:-2]}{{{{- end }}}}\n')
-                    lines.insert(j+4, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    lines.insert(j+3, '{{- end }}\n')
+                    lines.insert(j+4, '{{- end }}\n')
                     j += 5
 
             i = j

--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -29,6 +29,8 @@ from utils.git_sha_fetcher import fetch_sha_from_git_remote
 # Configure logging with coloredlogs
 coloredlogs.install(level='DEBUG')  # Set the logging level as needed
 
+# Removed literal_str class - using post-processing instead
+
 # Config Constants
 SCRIPT_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)))
 ROOT_DIR = os.path.abspath(os.path.join(SCRIPT_DIR, "..", ".."))
@@ -1072,6 +1074,53 @@ def injectHelmFlowControl(deployment, sizes, branch):
     a_file.close()
     logging.info("Added Helm flow control for NodeSelector, Proxy Overrides and SecCompProfile.\n")
 
+# add_probe_defaults adds explicit timeout and failure threshold values to probes (ACM 2.17+)
+def add_probe_defaults(deployment):
+    """
+    Adds default timeoutSeconds and failureThreshold to probes that don't have them.
+    Only applies to exec probes (like 'ls' commands) which are more susceptible to I/O delays.
+
+    This addresses ACM-29011 where customers on compact clusters or slow I/O systems
+    experience frequent probe timeouts with the Kubernetes default of 1 second.
+
+    Note: This function is only called for ACM 2.17+ and MCE 2.17+ releases.
+
+    Args:
+        deployment (dict): The deployment manifest to update
+    """
+    def update_single_probe(probe, probe_type, container_name, deployment_name):
+        """Helper to update a single probe with template defaults"""
+        # Only add defaults if it's an exec probe (not httpGet/tcpSocket)
+        if 'exec' not in probe:
+            return False
+
+        modified = False
+        if 'timeoutSeconds' not in probe:
+            probe['timeoutSeconds'] = '{{ .Values.hubconfig.probeTimeoutSeconds | default 10 }}'
+            logging.info(f"  Added timeoutSeconds template to {probe_type} in {deployment_name}/{container_name}")
+            modified = True
+        if 'failureThreshold' not in probe:
+            probe['failureThreshold'] = '{{ .Values.hubconfig.probeFailureThreshold | default 3 }}'
+            logging.info(f"  Added failureThreshold template to {probe_type} in {deployment_name}/{container_name}")
+            modified = True
+        return modified
+
+    deployment_name = deployment.get('metadata', {}).get('name', 'unknown')
+    containers = deployment.get('spec', {}).get('template', {}).get('spec', {}).get('containers', [])
+
+    modified = False
+    for container in containers:
+        container_name = container.get('name', 'unknown')
+
+        # Update all probe types (liveness, readiness, startup)
+        for probe_type in ['livenessProbe', 'readinessProbe', 'startupProbe']:
+            if probe_type in container:
+                if update_single_probe(container[probe_type], probe_type, container_name, deployment_name):
+                    modified = True
+
+    if modified:
+        logging.info(f"Applied probe defaults to deployment '{deployment_name}'")
+
 # updateDeployments adds standard configuration to the deployments (antiaffinity, security policies, and tolerations)
 def updateDeployments(helmChart, operator, exclusions, sizes, branch):
     """_summary_
@@ -1126,11 +1175,26 @@ def updateDeployments(helmChart, operator, exclusions, sizes, branch):
         pod_template_spec['nodeSelector'] = ""
         pod_template_spec['imagePullSecrets'] = ''
 
+        # Add probe defaults to exec probes that don't have explicit timeouts (ACM 2.17+)
+        if is_version_compatible(branch, '2.17', '2.17', '2.17'):
+            add_probe_defaults(deploy)
+
         with open(deployment, 'w', encoding='utf-8') as f:
-            yaml.dump(deploy, f)
+            yaml.dump(deploy, f, width=float("inf"))
+
         logging.info("Deployments updated with antiaffinity, security policies, and tolerations successfully. \n")
 
         injectHelmFlowControl(deployment, sizes, branch)
+
+        # Post-process to remove quotes from Helm template expressions for integer values
+        # This must be done AFTER injectHelmFlowControl since that function reads the YAML
+        with open(deployment, 'r', encoding='utf-8') as f:
+            content = f.read()
+        # Remove quotes around template expressions that should be integers (probeTimeoutSeconds, probeFailureThreshold)
+        content = content.replace("'{{ .Values.hubconfig.probeTimeoutSeconds | default 10 }}'", "{{ .Values.hubconfig.probeTimeoutSeconds | default 10 }}")
+        content = content.replace("'{{ .Values.hubconfig.probeFailureThreshold | default 3 }}'", "{{ .Values.hubconfig.probeFailureThreshold | default 3 }}")
+        with open(deployment, 'w', encoding='utf-8') as f:
+            f.write(content)
 
 # updateRBAC adds standard configuration to the RBAC resources (clusterroles, roles, clusterrolebindings, and rolebindings)
 def updateRBAC(helmChart, branch):

--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -1074,6 +1074,24 @@ def injectHelmFlowControl(deployment, sizes, branch):
     a_file.close()
     logging.info("Added Helm flow control for NodeSelector, Proxy Overrides and SecCompProfile.\n")
 
+def _add_probe_config_template(indent_str, field_name):
+    """Helper function to generate probe config template lines for a given field.
+
+    Args:
+        indent_str (str): The indentation string for the probe field
+        field_name (str): The probe config field name (e.g., 'timeoutSeconds', 'failureThreshold')
+
+    Returns:
+        list: Template lines for the probe config field
+    """
+    return [
+        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
+        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.{field_name} }}}}',
+        f'{indent_str}{field_name}: {{{{ .Values.hubconfig.probeConfig.{field_name} }}}}',
+        f'{indent_str[:-2]}{{{{- end }}}}',
+        f'{indent_str[:-2]}{{{{- end }}}}'
+    ]
+
 # inject_probe_config_helm_templates injects conditional probeConfig templates (ACM 2.17+)
 def inject_probe_config_helm_templates(deployment_file):
     """
@@ -1153,31 +1171,13 @@ def inject_probe_config_helm_templates(deployment_file):
                 templates_to_add = []
 
                 if not has_timeout:
-                    templates_to_add.extend([
-                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
-                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}}}',
-                        f'{indent_str}timeoutSeconds: {{{{ .Values.hubconfig.probeConfig.timeoutSeconds }}}}',
-                        f'{indent_str[:-2]}{{{{- end }}}}',
-                        f'{indent_str[:-2]}{{{{- end }}}}'
-                    ])
+                    templates_to_add.extend(_add_probe_config_template(indent_str, 'timeoutSeconds'))
 
                 if not has_failure:
-                    templates_to_add.extend([
-                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
-                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.failureThreshold }}}}',
-                        f'{indent_str}failureThreshold: {{{{ .Values.hubconfig.probeConfig.failureThreshold }}}}',
-                        f'{indent_str[:-2]}{{{{- end }}}}',
-                        f'{indent_str[:-2]}{{{{- end }}}}'
-                    ])
+                    templates_to_add.extend(_add_probe_config_template(indent_str, 'failureThreshold'))
 
                 if not has_success:
-                    templates_to_add.extend([
-                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
-                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.successThreshold }}}}',
-                        f'{indent_str}successThreshold: {{{{ .Values.hubconfig.probeConfig.successThreshold }}}}',
-                        f'{indent_str[:-2]}{{{{- end }}}}',
-                        f'{indent_str[:-2]}{{{{- end }}}}'
-                    ])
+                    templates_to_add.extend(_add_probe_config_template(indent_str, 'successThreshold'))
 
                 # Insert templates after the last probe field
                 if templates_to_add:

--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -1074,24 +1074,6 @@ def injectHelmFlowControl(deployment, sizes, branch):
     a_file.close()
     logging.info("Added Helm flow control for NodeSelector, Proxy Overrides and SecCompProfile.\n")
 
-def _add_probe_config_template(indent_str, field_name):
-    """Helper function to generate probe config template lines for a given field.
-
-    Args:
-        indent_str (str): The indentation string for the probe field
-        field_name (str): The probe config field name (e.g., 'timeoutSeconds', 'failureThreshold')
-
-    Returns:
-        list: Template lines for the probe config field
-    """
-    return [
-        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
-        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.{field_name} }}}}',
-        f'{indent_str}{field_name}: {{{{ .Values.hubconfig.probeConfig.{field_name} }}}}',
-        f'{indent_str[:-2]}{{{{- end }}}}',
-        f'{indent_str[:-2]}{{{{- end }}}}'
-    ]
-
 # inject_probe_config_helm_templates injects conditional probeConfig templates (ACM 2.17+)
 def inject_probe_config_helm_templates(deployment_file):
     """
@@ -1118,81 +1100,63 @@ def inject_probe_config_helm_templates(deployment_file):
     import re
 
     with open(deployment_file, 'r', encoding='utf-8') as f:
-        content = f.read()
+        lines = f.readlines()
 
-    lines = content.split('\n')
-    new_lines = []
     i = 0
-
     while i < len(lines):
         line = lines[i]
-        new_lines.append(line)
 
-        # Detect probe sections (livenessProbe, readinessProbe, startupProbe)
+        # Find probe sections
         probe_match = re.match(r'^(\s+)(livenessProbe|readinessProbe|startupProbe):\s*$', line)
         if probe_match:
-            probe_indent = len(probe_match.group(1))
-            value_indent = probe_indent + 2
-            indent_str = ' ' * value_indent
+            base_indent = len(probe_match.group(1))
+            field_indent = ' ' * (base_indent + 2)
 
-            # Look ahead to check if this is an exec probe and what fields exist
+            # Collect the probe section
+            probe_section = []
             j = i + 1
-            is_exec_probe = False
-            has_timeout = False
-            has_failure = False
-            has_success = False
-            last_probe_line = i
-
-            while j < len(lines):
-                next_line = lines[j]
-                if next_line.strip():  # Skip empty lines
-                    next_indent = len(next_line) - len(next_line.lstrip())
-
-                    # If indent decreased, we've left the probe section
-                    if next_indent <= probe_indent:
-                        break
-
-                    if next_indent == value_indent:
-                        if 'exec:' in next_line:
-                            is_exec_probe = True
-                        if 'timeoutSeconds:' in next_line:
-                            has_timeout = True
-                        if 'failureThreshold:' in next_line:
-                            has_failure = True
-                        if 'successThreshold:' in next_line:
-                            has_success = True
-                        last_probe_line = j
-
-                new_lines.append(lines[j])
+            while j < len(lines) and lines[j].strip():
+                line_indent = len(lines[j]) - len(lines[j].lstrip())
+                if line_indent <= base_indent:
+                    break
+                probe_section.append(lines[j])
                 j += 1
 
-            # If it's an exec probe and missing fields, inject conditional templates
-            if is_exec_probe:
-                templates_to_add = []
+            probe_text = ''.join(probe_section)
 
-                if not has_timeout:
-                    templates_to_add.extend(_add_probe_config_template(indent_str, 'timeoutSeconds'))
+            # Only process exec probes
+            if 'exec:' in probe_text:
+                # Append missing fields
+                if 'timeoutSeconds:' not in probe_text:
+                    lines.insert(j, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}\n')
+                    lines.insert(j+1, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}}}\n')
+                    lines.insert(j+2, f'{field_indent}timeoutSeconds: {{{{ .Values.hubconfig.probeConfig.timeoutSeconds }}}}\n')
+                    lines.insert(j+3, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    lines.insert(j+4, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    j += 5
 
-                if not has_failure:
-                    templates_to_add.extend(_add_probe_config_template(indent_str, 'failureThreshold'))
+                if 'failureThreshold:' not in probe_text:
+                    lines.insert(j, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}\n')
+                    lines.insert(j+1, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig.failureThreshold }}}}\n')
+                    lines.insert(j+2, f'{field_indent}failureThreshold: {{{{ .Values.hubconfig.probeConfig.failureThreshold }}}}\n')
+                    lines.insert(j+3, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    lines.insert(j+4, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    j += 5
 
-                if not has_success:
-                    templates_to_add.extend(_add_probe_config_template(indent_str, 'successThreshold'))
+                if 'successThreshold:' not in probe_text:
+                    lines.insert(j, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}\n')
+                    lines.insert(j+1, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig.successThreshold }}}}\n')
+                    lines.insert(j+2, f'{field_indent}successThreshold: {{{{ .Values.hubconfig.probeConfig.successThreshold }}}}\n')
+                    lines.insert(j+3, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    lines.insert(j+4, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    j += 5
 
-                # Insert templates after the last probe field
-                if templates_to_add:
-                    new_lines.extend(templates_to_add)
-                    logging.info(f"  Injected probeConfig templates for {probe_match.group(2)} in {deployment_file}")
-
-            # Skip the lines we already processed
             i = j
-            continue
+        else:
+            i += 1
 
-        i += 1
-
-    # Write updated content
     with open(deployment_file, 'w', encoding='utf-8') as f:
-        f.write('\n'.join(new_lines))
+        f.writelines(lines)
 
 # updateDeployments adds standard configuration to the deployments (antiaffinity, security policies, and tolerations)
 def updateDeployments(helmChart, operator, exclusions, sizes, branch):

--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -656,52 +656,125 @@ def addPullSecretOverride(deployment):
         a_file.writelines(lines)
         a_file.close()
 
-# add_probe_defaults adds explicit timeout and failure threshold values to probes (ACM 2.17+)
-def add_probe_defaults(deployment):
+# inject_probe_config_helm_templates injects conditional probeConfig templates (ACM 2.17+)
+def inject_probe_config_helm_templates(deployment_file):
     """
-    Adds default timeoutSeconds and failureThreshold to probes that don't have them.
-    Only applies to exec probes (like 'ls' commands) which are more susceptible to I/O delays.
+    Injects conditional Helm templates for probe configuration into deployment files.
+
+    Adds template blocks for exec probes that allow users to optionally configure:
+    - timeoutSeconds (K8s default: 1)
+    - failureThreshold (K8s default: 3)
+    - successThreshold (K8s default: 1)
 
     This addresses ACM-29011 where customers on compact clusters or slow I/O systems
-    experience frequent probe timeouts with the Kubernetes default of 1 second.
+    experience frequent probe timeouts. Rather than forcing new defaults on all users,
+    this allows opt-in configuration via MCH CR probeConfig field while preserving
+    Kubernetes defaults when not configured.
+
+    Only applies to exec probes (not httpGet/tcpSocket). Only injects if values don't
+    already exist in the template.
 
     Note: This function is only called for ACM 2.17+ and MCE 2.17+ releases.
 
     Args:
-        deployment (dict): The deployment manifest to update
+        deployment_file (str): Path to the deployment YAML file to update
     """
-    def update_single_probe(probe, probe_type, container_name, deployment_name):
-        """Helper to update a single probe with template defaults"""
-        # Only add defaults if it's an exec probe (not httpGet/tcpSocket)
-        if 'exec' not in probe:
-            return False
+    import re
 
-        modified = False
-        if 'timeoutSeconds' not in probe:
-            probe['timeoutSeconds'] = '{{ .Values.hubconfig.probeTimeoutSeconds | default 10 }}'
-            logging.info(f"  Added timeoutSeconds template to {probe_type} in {deployment_name}/{container_name}")
-            modified = True
-        if 'failureThreshold' not in probe:
-            probe['failureThreshold'] = '{{ .Values.hubconfig.probeFailureThreshold | default 3 }}'
-            logging.info(f"  Added failureThreshold template to {probe_type} in {deployment_name}/{container_name}")
-            modified = True
-        return modified
+    with open(deployment_file, 'r', encoding='utf-8') as f:
+        content = f.read()
 
-    deployment_name = deployment.get('metadata', {}).get('name', 'unknown')
-    containers = deployment.get('spec', {}).get('template', {}).get('spec', {}).get('containers', [])
+    lines = content.split('\n')
+    new_lines = []
+    i = 0
 
-    modified = False
-    for container in containers:
-        container_name = container.get('name', 'unknown')
+    while i < len(lines):
+        line = lines[i]
+        new_lines.append(line)
 
-        # Update all probe types (liveness, readiness, startup)
-        for probe_type in ['livenessProbe', 'readinessProbe', 'startupProbe']:
-            if probe_type in container:
-                if update_single_probe(container[probe_type], probe_type, container_name, deployment_name):
-                    modified = True
+        # Detect probe sections (livenessProbe, readinessProbe, startupProbe)
+        probe_match = re.match(r'^(\s+)(livenessProbe|readinessProbe|startupProbe):\s*$', line)
+        if probe_match:
+            probe_indent = len(probe_match.group(1))
+            value_indent = probe_indent + 2
+            indent_str = ' ' * value_indent
 
-    if modified:
-        logging.info(f"Applied probe defaults to deployment '{deployment_name}'")
+            # Look ahead to check if this is an exec probe and what fields exist
+            j = i + 1
+            is_exec_probe = False
+            has_timeout = False
+            has_failure = False
+            has_success = False
+            last_probe_line = i
+
+            while j < len(lines):
+                next_line = lines[j]
+                if next_line.strip():  # Skip empty lines
+                    next_indent = len(next_line) - len(next_line.lstrip())
+
+                    # If indent decreased, we've left the probe section
+                    if next_indent <= probe_indent:
+                        break
+
+                    if next_indent == value_indent:
+                        if 'exec:' in next_line:
+                            is_exec_probe = True
+                        if 'timeoutSeconds:' in next_line:
+                            has_timeout = True
+                        if 'failureThreshold:' in next_line:
+                            has_failure = True
+                        if 'successThreshold:' in next_line:
+                            has_success = True
+                        last_probe_line = j
+
+                new_lines.append(lines[j])
+                j += 1
+
+            # If it's an exec probe and missing fields, inject conditional templates
+            if is_exec_probe:
+                templates_to_add = []
+
+                if not has_timeout:
+                    templates_to_add.extend([
+                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
+                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}}}',
+                        f'{indent_str}timeoutSeconds: {{{{ .Values.hubconfig.probeConfig.timeoutSeconds }}}}',
+                        f'{indent_str[:-2]}{{{{- end }}}}',
+                        f'{indent_str[:-2]}{{{{- end }}}}'
+                    ])
+
+                if not has_failure:
+                    templates_to_add.extend([
+                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
+                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.failureThreshold }}}}',
+                        f'{indent_str}failureThreshold: {{{{ .Values.hubconfig.probeConfig.failureThreshold }}}}',
+                        f'{indent_str[:-2]}{{{{- end }}}}',
+                        f'{indent_str[:-2]}{{{{- end }}}}'
+                    ])
+
+                if not has_success:
+                    templates_to_add.extend([
+                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
+                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.successThreshold }}}}',
+                        f'{indent_str}successThreshold: {{{{ .Values.hubconfig.probeConfig.successThreshold }}}}',
+                        f'{indent_str[:-2]}{{{{- end }}}}',
+                        f'{indent_str[:-2]}{{{{- end }}}}'
+                    ])
+
+                # Insert templates after the last probe field
+                if templates_to_add:
+                    new_lines.extend(templates_to_add)
+                    logging.info(f"  Injected probeConfig templates for {probe_match.group(2)} in {deployment_file}")
+
+            # Skip the lines we already processed
+            i = j
+            continue
+
+        i += 1
+
+    # Write updated content
+    with open(deployment_file, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(new_lines))
 
 # updateDeployments adds standard configuration to the deployments (antiaffinity, security policies, and tolerations)
 def updateDeployments(chartName, helmChart, exclusions, inclusions, branch):
@@ -728,10 +801,6 @@ def updateDeployments(chartName, helmChart, exclusions, inclusions, branch):
         deploy['spec']['template']['spec']['nodeSelector'] = ""
         deploy['spec']['template']['spec']['imagePullSecrets'] = ''
 
-        # Add probe defaults to exec probes that don't have explicit timeouts (ACM 2.17+)
-        if is_version_compatible(branch, '2.17', '2.17', '2.17'):
-            add_probe_defaults(deploy)
-
         with open(deployment, 'w') as f:
             yaml.dump(deploy, f, width=float("inf"))
 
@@ -739,15 +808,11 @@ def updateDeployments(chartName, helmChart, exclusions, inclusions, branch):
 
         injectHelmFlowControl(deployment, branch)
 
-        # Post-process to remove quotes from Helm template expressions for integer values
-        # This must be done AFTER injectHelmFlowControl since that function reads the YAML
-        with open(deployment, 'r') as f:
-            content = f.read()
-        # Remove quotes around template expressions that should be integers (probeTimeoutSeconds, probeFailureThreshold)
-        content = content.replace("'{{ .Values.hubconfig.probeTimeoutSeconds | default 10 }}'", "{{ .Values.hubconfig.probeTimeoutSeconds | default 10 }}")
-        content = content.replace("'{{ .Values.hubconfig.probeFailureThreshold | default 3 }}'", "{{ .Values.hubconfig.probeFailureThreshold | default 3 }}")
-        with open(deployment, 'w') as f:
-            f.write(content)
+        # Inject conditional probe config templates (ACM 2.17+)
+        # This must be done AFTER injectHelmFlowControl since that function manipulates the YAML
+        if is_version_compatible(branch, '2.17', '2.17', '2.17'):
+            inject_probe_config_helm_templates(deployment)
+
         if 'pullSecretOverride' in inclusions:
             addPullSecretOverride(deployment)
 

--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -656,24 +656,6 @@ def addPullSecretOverride(deployment):
         a_file.writelines(lines)
         a_file.close()
 
-def _add_probe_config_template(indent_str, field_name):
-    """Helper function to generate probe config template lines for a given field.
-
-    Args:
-        indent_str (str): The indentation string for the probe field
-        field_name (str): The probe config field name (e.g., 'timeoutSeconds', 'failureThreshold')
-
-    Returns:
-        list: Template lines for the probe config field
-    """
-    return [
-        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
-        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.{field_name} }}}}',
-        f'{indent_str}{field_name}: {{{{ .Values.hubconfig.probeConfig.{field_name} }}}}',
-        f'{indent_str[:-2]}{{{{- end }}}}',
-        f'{indent_str[:-2]}{{{{- end }}}}'
-    ]
-
 # inject_probe_config_helm_templates injects conditional probeConfig templates (ACM 2.17+)
 def inject_probe_config_helm_templates(deployment_file):
     """
@@ -700,81 +682,63 @@ def inject_probe_config_helm_templates(deployment_file):
     import re
 
     with open(deployment_file, 'r', encoding='utf-8') as f:
-        content = f.read()
+        lines = f.readlines()
 
-    lines = content.split('\n')
-    new_lines = []
     i = 0
-
     while i < len(lines):
         line = lines[i]
-        new_lines.append(line)
 
-        # Detect probe sections (livenessProbe, readinessProbe, startupProbe)
+        # Find probe sections
         probe_match = re.match(r'^(\s+)(livenessProbe|readinessProbe|startupProbe):\s*$', line)
         if probe_match:
-            probe_indent = len(probe_match.group(1))
-            value_indent = probe_indent + 2
-            indent_str = ' ' * value_indent
+            base_indent = len(probe_match.group(1))
+            field_indent = ' ' * (base_indent + 2)
 
-            # Look ahead to check if this is an exec probe and what fields exist
+            # Collect the probe section
+            probe_section = []
             j = i + 1
-            is_exec_probe = False
-            has_timeout = False
-            has_failure = False
-            has_success = False
-            last_probe_line = i
-
-            while j < len(lines):
-                next_line = lines[j]
-                if next_line.strip():  # Skip empty lines
-                    next_indent = len(next_line) - len(next_line.lstrip())
-
-                    # If indent decreased, we've left the probe section
-                    if next_indent <= probe_indent:
-                        break
-
-                    if next_indent == value_indent:
-                        if 'exec:' in next_line:
-                            is_exec_probe = True
-                        if 'timeoutSeconds:' in next_line:
-                            has_timeout = True
-                        if 'failureThreshold:' in next_line:
-                            has_failure = True
-                        if 'successThreshold:' in next_line:
-                            has_success = True
-                        last_probe_line = j
-
-                new_lines.append(lines[j])
+            while j < len(lines) and lines[j].strip():
+                line_indent = len(lines[j]) - len(lines[j].lstrip())
+                if line_indent <= base_indent:
+                    break
+                probe_section.append(lines[j])
                 j += 1
 
-            # If it's an exec probe and missing fields, inject conditional templates
-            if is_exec_probe:
-                templates_to_add = []
+            probe_text = ''.join(probe_section)
 
-                if not has_timeout:
-                    templates_to_add.extend(_add_probe_config_template(indent_str, 'timeoutSeconds'))
+            # Only process exec probes
+            if 'exec:' in probe_text:
+                # Append missing fields
+                if 'timeoutSeconds:' not in probe_text:
+                    lines.insert(j, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}\n')
+                    lines.insert(j+1, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}}}\n')
+                    lines.insert(j+2, f'{field_indent}timeoutSeconds: {{{{ .Values.hubconfig.probeConfig.timeoutSeconds }}}}\n')
+                    lines.insert(j+3, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    lines.insert(j+4, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    j += 5
 
-                if not has_failure:
-                    templates_to_add.extend(_add_probe_config_template(indent_str, 'failureThreshold'))
+                if 'failureThreshold:' not in probe_text:
+                    lines.insert(j, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}\n')
+                    lines.insert(j+1, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig.failureThreshold }}}}\n')
+                    lines.insert(j+2, f'{field_indent}failureThreshold: {{{{ .Values.hubconfig.probeConfig.failureThreshold }}}}\n')
+                    lines.insert(j+3, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    lines.insert(j+4, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    j += 5
 
-                if not has_success:
-                    templates_to_add.extend(_add_probe_config_template(indent_str, 'successThreshold'))
+                if 'successThreshold:' not in probe_text:
+                    lines.insert(j, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}\n')
+                    lines.insert(j+1, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig.successThreshold }}}}\n')
+                    lines.insert(j+2, f'{field_indent}successThreshold: {{{{ .Values.hubconfig.probeConfig.successThreshold }}}}\n')
+                    lines.insert(j+3, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    lines.insert(j+4, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    j += 5
 
-                # Insert templates after the last probe field
-                if templates_to_add:
-                    new_lines.extend(templates_to_add)
-                    logging.info(f"  Injected probeConfig templates for {probe_match.group(2)} in {deployment_file}")
-
-            # Skip the lines we already processed
             i = j
-            continue
+        else:
+            i += 1
 
-        i += 1
-
-    # Write updated content
     with open(deployment_file, 'w', encoding='utf-8') as f:
-        f.write('\n'.join(new_lines))
+        f.writelines(lines)
 
 # updateDeployments adds standard configuration to the deployments (antiaffinity, security policies, and tolerations)
 def updateDeployments(chartName, helmChart, exclusions, inclusions, branch):

--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -19,6 +19,8 @@ from validate_csv import *
 # Configure logging with coloredlogs
 coloredlogs.install(level='DEBUG')  # Set the logging level as needed
 
+# Removed literal_str class - using post-processing instead
+
 # Config Constants
 SCRIPT_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)))
 ROOT_DIR = os.path.abspath(os.path.join(SCRIPT_DIR, "..", ".."))
@@ -654,6 +656,53 @@ def addPullSecretOverride(deployment):
         a_file.writelines(lines)
         a_file.close()
 
+# add_probe_defaults adds explicit timeout and failure threshold values to probes (ACM 2.17+)
+def add_probe_defaults(deployment):
+    """
+    Adds default timeoutSeconds and failureThreshold to probes that don't have them.
+    Only applies to exec probes (like 'ls' commands) which are more susceptible to I/O delays.
+
+    This addresses ACM-29011 where customers on compact clusters or slow I/O systems
+    experience frequent probe timeouts with the Kubernetes default of 1 second.
+
+    Note: This function is only called for ACM 2.17+ and MCE 2.17+ releases.
+
+    Args:
+        deployment (dict): The deployment manifest to update
+    """
+    def update_single_probe(probe, probe_type, container_name, deployment_name):
+        """Helper to update a single probe with template defaults"""
+        # Only add defaults if it's an exec probe (not httpGet/tcpSocket)
+        if 'exec' not in probe:
+            return False
+
+        modified = False
+        if 'timeoutSeconds' not in probe:
+            probe['timeoutSeconds'] = '{{ .Values.hubconfig.probeTimeoutSeconds | default 10 }}'
+            logging.info(f"  Added timeoutSeconds template to {probe_type} in {deployment_name}/{container_name}")
+            modified = True
+        if 'failureThreshold' not in probe:
+            probe['failureThreshold'] = '{{ .Values.hubconfig.probeFailureThreshold | default 3 }}'
+            logging.info(f"  Added failureThreshold template to {probe_type} in {deployment_name}/{container_name}")
+            modified = True
+        return modified
+
+    deployment_name = deployment.get('metadata', {}).get('name', 'unknown')
+    containers = deployment.get('spec', {}).get('template', {}).get('spec', {}).get('containers', [])
+
+    modified = False
+    for container in containers:
+        container_name = container.get('name', 'unknown')
+
+        # Update all probe types (liveness, readiness, startup)
+        for probe_type in ['livenessProbe', 'readinessProbe', 'startupProbe']:
+            if probe_type in container:
+                if update_single_probe(container[probe_type], probe_type, container_name, deployment_name):
+                    modified = True
+
+    if modified:
+        logging.info(f"Applied probe defaults to deployment '{deployment_name}'")
+
 # updateDeployments adds standard configuration to the deployments (antiaffinity, security policies, and tolerations)
 def updateDeployments(chartName, helmChart, exclusions, inclusions, branch):
     logging.info("Updating deployments with antiaffinity, security policies, and tolerations ...")
@@ -678,12 +727,27 @@ def updateDeployments(chartName, helmChart, exclusions, inclusions, branch):
         deploy['spec']['template']['metadata']['labels']['ocm-antiaffinity-selector'] = deploy['metadata']['name']
         deploy['spec']['template']['spec']['nodeSelector'] = ""
         deploy['spec']['template']['spec']['imagePullSecrets'] = ''
-        
+
+        # Add probe defaults to exec probes that don't have explicit timeouts (ACM 2.17+)
+        if is_version_compatible(branch, '2.17', '2.17', '2.17'):
+            add_probe_defaults(deploy)
+
         with open(deployment, 'w') as f:
             yaml.dump(deploy, f, width=float("inf"))
+
         logging.info("Deployments updated with antiaffinity, security policies, and tolerations successfully. \n")
 
         injectHelmFlowControl(deployment, branch)
+
+        # Post-process to remove quotes from Helm template expressions for integer values
+        # This must be done AFTER injectHelmFlowControl since that function reads the YAML
+        with open(deployment, 'r') as f:
+            content = f.read()
+        # Remove quotes around template expressions that should be integers (probeTimeoutSeconds, probeFailureThreshold)
+        content = content.replace("'{{ .Values.hubconfig.probeTimeoutSeconds | default 10 }}'", "{{ .Values.hubconfig.probeTimeoutSeconds | default 10 }}")
+        content = content.replace("'{{ .Values.hubconfig.probeFailureThreshold | default 3 }}'", "{{ .Values.hubconfig.probeFailureThreshold | default 3 }}")
+        with open(deployment, 'w') as f:
+            f.write(content)
         if 'pullSecretOverride' in inclusions:
             addPullSecretOverride(deployment)
 

--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -656,6 +656,24 @@ def addPullSecretOverride(deployment):
         a_file.writelines(lines)
         a_file.close()
 
+def _add_probe_config_template(indent_str, field_name):
+    """Helper function to generate probe config template lines for a given field.
+
+    Args:
+        indent_str (str): The indentation string for the probe field
+        field_name (str): The probe config field name (e.g., 'timeoutSeconds', 'failureThreshold')
+
+    Returns:
+        list: Template lines for the probe config field
+    """
+    return [
+        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
+        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.{field_name} }}}}',
+        f'{indent_str}{field_name}: {{{{ .Values.hubconfig.probeConfig.{field_name} }}}}',
+        f'{indent_str[:-2]}{{{{- end }}}}',
+        f'{indent_str[:-2]}{{{{- end }}}}'
+    ]
+
 # inject_probe_config_helm_templates injects conditional probeConfig templates (ACM 2.17+)
 def inject_probe_config_helm_templates(deployment_file):
     """
@@ -735,31 +753,13 @@ def inject_probe_config_helm_templates(deployment_file):
                 templates_to_add = []
 
                 if not has_timeout:
-                    templates_to_add.extend([
-                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
-                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}}}',
-                        f'{indent_str}timeoutSeconds: {{{{ .Values.hubconfig.probeConfig.timeoutSeconds }}}}',
-                        f'{indent_str[:-2]}{{{{- end }}}}',
-                        f'{indent_str[:-2]}{{{{- end }}}}'
-                    ])
+                    templates_to_add.extend(_add_probe_config_template(indent_str, 'timeoutSeconds'))
 
                 if not has_failure:
-                    templates_to_add.extend([
-                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
-                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.failureThreshold }}}}',
-                        f'{indent_str}failureThreshold: {{{{ .Values.hubconfig.probeConfig.failureThreshold }}}}',
-                        f'{indent_str[:-2]}{{{{- end }}}}',
-                        f'{indent_str[:-2]}{{{{- end }}}}'
-                    ])
+                    templates_to_add.extend(_add_probe_config_template(indent_str, 'failureThreshold'))
 
                 if not has_success:
-                    templates_to_add.extend([
-                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}',
-                        f'{indent_str[:-2]}{{{{- if .Values.hubconfig.probeConfig.successThreshold }}}}',
-                        f'{indent_str}successThreshold: {{{{ .Values.hubconfig.probeConfig.successThreshold }}}}',
-                        f'{indent_str[:-2]}{{{{- end }}}}',
-                        f'{indent_str[:-2]}{{{{- end }}}}'
-                    ])
+                    templates_to_add.extend(_add_probe_config_template(indent_str, 'successThreshold'))
 
                 # Insert templates after the last probe field
                 if templates_to_add:

--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -710,27 +710,27 @@ def inject_probe_config_helm_templates(deployment_file):
             if 'exec:' in probe_text:
                 # Append missing fields
                 if 'timeoutSeconds:' not in probe_text:
-                    lines.insert(j, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}\n')
-                    lines.insert(j+1, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}}}\n')
+                    lines.insert(j, '{{- if .Values.hubconfig.probeConfig }}\n')
+                    lines.insert(j+1, '{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}\n')
                     lines.insert(j+2, f'{field_indent}timeoutSeconds: {{{{ .Values.hubconfig.probeConfig.timeoutSeconds }}}}\n')
-                    lines.insert(j+3, f'{field_indent[:-2]}{{{{- end }}}}\n')
-                    lines.insert(j+4, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    lines.insert(j+3, '{{- end }}\n')
+                    lines.insert(j+4, '{{- end }}\n')
                     j += 5
 
                 if 'failureThreshold:' not in probe_text:
-                    lines.insert(j, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}\n')
-                    lines.insert(j+1, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig.failureThreshold }}}}\n')
+                    lines.insert(j, '{{- if .Values.hubconfig.probeConfig }}\n')
+                    lines.insert(j+1, '{{- if .Values.hubconfig.probeConfig.failureThreshold }}\n')
                     lines.insert(j+2, f'{field_indent}failureThreshold: {{{{ .Values.hubconfig.probeConfig.failureThreshold }}}}\n')
-                    lines.insert(j+3, f'{field_indent[:-2]}{{{{- end }}}}\n')
-                    lines.insert(j+4, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    lines.insert(j+3, '{{- end }}\n')
+                    lines.insert(j+4, '{{- end }}\n')
                     j += 5
 
                 if 'successThreshold:' not in probe_text:
-                    lines.insert(j, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig }}}}\n')
-                    lines.insert(j+1, f'{field_indent[:-2]}{{{{- if .Values.hubconfig.probeConfig.successThreshold }}}}\n')
+                    lines.insert(j, '{{- if .Values.hubconfig.probeConfig }}\n')
+                    lines.insert(j+1, '{{- if .Values.hubconfig.probeConfig.successThreshold }}\n')
                     lines.insert(j+2, f'{field_indent}successThreshold: {{{{ .Values.hubconfig.probeConfig.successThreshold }}}}\n')
-                    lines.insert(j+3, f'{field_indent[:-2]}{{{{- end }}}}\n')
-                    lines.insert(j+4, f'{field_indent[:-2]}{{{{- end }}}}\n')
+                    lines.insert(j+3, '{{- end }}\n')
+                    lines.insert(j+4, '{{- end }}\n')
                     j += 5
 
             i = j


### PR DESCRIPTION
## Summary

This PR adds conditional Helm templates for probe configuration (timeoutSeconds, failureThreshold, successThreshold) to exec-based probes in generated Helm charts. This enables opt-in probe customization via MultiClusterHub CR without forcing new defaults on all users.

## Problem

Fixes ACM-29011 where customers running ACM on compact clusters or systems with slow I/O experience frequent probe timeout failures with Kubernetes' default 1-second timeout.

The customer reported timeout failures on:
- `ocm-webhook` (multicluster-engine namespace)  
- `cluster-permission` (open-cluster-management namespace) - **Note**: migrating to MCE in 2.17
- `grc-policy-propagator` (open-cluster-management namespace)
- `multicluster-integrations` (open-cluster-management namespace)

Currently, most exec probes in our Helm charts don't specify explicit `timeoutSeconds`, so they default to Kubernetes' 1-second timeout. This is too aggressive for exec probes (like `ls` commands) in resource-constrained environments.

## Solution

Adds conditional Helm template blocks that allow users to optionally configure probe settings via MultiClusterHub CR while **preserving Kubernetes defaults when not configured**:

```yaml
livenessProbe:
  exec:
    command:
    - ls
  initialDelaySeconds: 15
  periodSeconds: 15
{{- if .Values.hubconfig.probeConfig }}
{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}
  timeoutSeconds: {{ .Values.hubconfig.probeConfig.timeoutSeconds }}
{{- end }}
{{- if .Values.hubconfig.probeConfig.failureThreshold }}
  failureThreshold: {{ .Values.hubconfig.probeConfig.failureThreshold }}
{{- end }}
{{- if .Values.hubconfig.probeConfig.successThreshold }}
  successThreshold: {{ .Values.hubconfig.probeConfig.successThreshold }}
{{- end }}
{{- end }}
```

**Key features:**
- **Opt-in configuration**: No values injected unless user explicitly configures them
- **Preserves Kubernetes defaults**: timeoutSeconds=1, failureThreshold=3, successThreshold=1
- Nested structure: `.Values.hubconfig.probeConfig.timeoutSeconds` (not flat)
- Users can override via MultiClusterHub CR `spec.probeConfig` field
- Only applies to **exec probes** (httpGet and tcpSocket probes unchanged)
- Only injects if values don't **already exist** in the template
- Supports all three probe types: liveness, readiness, startup

This covers both chart generation workflows:
- `make regenerate-charts-from-bundles` (bundles-to-charts.py)
- `make regenerate-charts` (generate-charts.py)

## Industry Best Practices

According to [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) and production guides:
- Default `timeoutSeconds: 1` is considered "very aggressive"
- Recommended values: 2-10 seconds for exec probes depending on environment
- Fast checks: 2-5s, Standard checks: 5s, Complex checks: 10s

Rather than forcing new defaults on all users, this approach allows customers experiencing issues to opt-in to higher values while leaving other clusters unchanged.

## MultiClusterHub Operator Integration

The corresponding MCH operator PR adds `spec.probeConfig` to the MultiClusterHub CRD, allowing customers to configure:

```yaml
apiVersion: operator.open-cluster-management.io/v1
kind: MultiClusterHub
metadata:
  name: multiclusterhub
spec:
  # Optional: only specify if experiencing probe timeout issues
  probeConfig:
    timeoutSeconds: 10
    failureThreshold: 5
    successThreshold: 1
```

The operator rendering pipeline passes these values to Helm charts via `.Values.hubconfig.probeConfig`.

## Testing

After this PR is merged, component maintainers can regenerate their charts to pick up the probe configuration templates:

```bash
cd multiclusterhub-operator
COMPONENT="multicloud-operators-subscription" make -f Makefile.dev regenerate-charts-from-bundles
```

cc: @cameronmwall @ngraham20