### PR TITLE
Enable component teams to maintain OWNERS files for their charts

### DIFF
--- a/OWNERS_TEMPLATE.md
+++ b/OWNERS_TEMPLATE.md
@@ -1,0 +1,142 @@
+# Component OWNERS File Guide
+
+## Overview
+
+Component teams can now add OWNERS files to their chart directories in their upstream repositories. These OWNERS files will be automatically synced to operator repositories (multiclusterhub-operator, backplane-operator) during chart regeneration, allowing component teams to independently approve changes to their charts.
+
+## How It Works
+
+1. **Component teams** add an OWNERS file to their chart/bundle directory in their upstream repo
+2. **Automation** syncs the OWNERS file during `make regenerate-charts` / `make regenerate-charts-from-bundles`
+3. **Prow** uses the OWNERS file for PR approvals in the operator repository
+4. **Fallback**: Charts without upstream OWNERS files use the root OWNERS (Installer team)
+
+**Important:** Upstream is the single source of truth for automated charts:
+- **If upstream HAS OWNERS** → copied to operator repository (multiclusterhub-operator, backplane-operator)
+- **If upstream NO OWNERS** → any existing downstream OWNERS removed, fallback to root OWNERS (Installer team)
+
+**Do not manually add OWNERS to automated charts** in operator repositories - they will be removed on the next regeneration if they don't exist upstream.
+
+**Exception:** Charts manually maintained in operator repositories (not in automation config) can have manual OWNERS files - the automation won't touch them.
+
+## Where to Add OWNERS File
+
+### For Helm-based Components
+
+Add the OWNERS file to your chart directory in your component repository:
+
+```
+your-component-repo/
+└── deploy/
+    └── chart/                    # or wherever your chart lives
+        ├── Chart.yaml
+        ├── values.yaml
+        ├── templates/
+        └── OWNERS                # <-- Add this file
+```
+
+### For Bundle-based Components (OLM Operators)
+
+Add the OWNERS file to the root of your bundle repository:
+
+```
+your-operator-bundle-repo/
+├── bundle/
+│   └── manifests/
+│       └── your-operator.clusterserviceversion.yaml
+└── OWNERS                        # <-- Add this file
+```
+
+This will be copied to the operator repository (e.g., multiclusterhub-operator):
+```
+<operator-repo>/
+└── pkg/
+    └── templates/
+        └── charts/
+            └── toggle/
+                └── your-component/
+                    ├── Chart.yaml
+                    ├── values.yaml
+                    ├── templates/
+                    └── OWNERS    # <-- Auto-copied here
+```
+
+## OWNERS File Format
+
+Create an OWNERS file in YAML format:
+
+```yaml
+approvers:
+- github-username-1
+- github-username-2
+- github-username-3
+reviewers:
+- github-username-1
+- github-username-2
+- github-username-3
+- github-username-4
+```
+
+### Example: Component Team OWNERS
+
+```yaml
+approvers:
+- team-lead-1
+- team-lead-2
+- team-member-1
+reviewers:
+- team-lead-1
+- team-lead-2
+- team-member-1
+- team-member-2
+```
+
+## Approval Behavior
+
+### With Component OWNERS File
+
+**Scenario 1**: PR only touches your component's chart files
+- ✅ Your team can `/approve` and merge independently
+- ✅ Installer team can still approve if needed (Prow inheritance)
+
+**Scenario 2**: PR touches your component AND other files
+- ⚠️ Requires approvals from both:
+  - Your team member (for your component files)
+  - Root OWNERS or other component OWNERS (for other files)
+
+### Without Component OWNERS File
+
+- All PRs require approval from root OWNERS (Installer team)
+- This is the fallback behavior
+
+## Benefits
+
+- **Faster approvals**: Component teams don't need to wait for Installer team
+- **Better ownership**: Clear responsibility for component charts
+- **Flexibility**: Installer team can still approve when needed
+- **No duplication**: OWNERS maintained in component repos, auto-synced
+
+## FAQ
+
+**Q: Do we need to use `no_parent_owners: true`?**
+A: No. We use partial delegation, which allows both component teams AND the Installer team to approve.
+
+**Q: What if our upstream chart doesn't have an OWNERS file?**
+A: The chart will fallback to the root OWNERS file (Installer team) automatically.
+
+**Q: Can we update OWNERS without regenerating charts?**
+A: No. OWNERS files are synced during chart regeneration. Changes to OWNERS upstream will be picked up on the next regeneration.
+
+**Q: What about CRD OWNERS files?**
+A: Same pattern applies! Add OWNERS to your CRD directory and it will be copied to `pkg/templates/crds/your-component/OWNERS`.
+
+## Rollout Plan
+
+1. **Phase 1**: Merge this PR to installer-dev-tools
+2. **Phase 2**: Component teams add OWNERS files to their repos
+3. **Phase 3**: Next chart regeneration picks up OWNERS files
+4. **Phase 4**: Component teams can start approving their own PRs
+
+## Questions?
+
+Contact the Installer team (@cameronmwall, @dislbenn, @ngraham20) if you have questions about OWNERS files.

--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -23,8 +23,8 @@ import yaml
 
 from git import Repo, Git
 from packaging import version
-from validate_csv import *
 from utils.git_sha_fetcher import fetch_sha_from_git_remote
+from helper import sync_owners_file
 
 # Configure logging with coloredlogs
 coloredlogs.install(level='DEBUG')  # Set the logging level as needed
@@ -1359,6 +1359,10 @@ def addCRDs(repo, operator, outputDir, branch, preservedFiles=None, overwrite=Fa
                     logging.info("CRD file copied: %s", filename)
                 break  # Only copy the file once even if it has multiple CRDs
 
+    # Sync OWNERS file from upstream repository root for CRDs (upstream is single source of truth)
+    repo_path = os.path.join(SCRIPT_DIR, "tmp", repo)
+    sync_owners_file(repo_path, directoryPath, f"{operator['name']} CRDs")
+
     logging.info("CRDs added successfully for operator: %s", operator['name'])
 
 def getBundleManifestsPath(repo, operator):
@@ -1843,6 +1847,11 @@ def main():
 
             # Generate the Chart.yaml file based off of the CSV
             helmChart = os.path.join(destination, "charts", "toggle", operator["name"])
+
+            # Sync OWNERS file from upstream bundle repo (upstream is single source of truth)
+            repo_path = os.path.join(SCRIPT_DIR, "tmp", repo_name)
+            sync_owners_file(repo_path, helmChart, operator["name"])
+
             logging.info("Filling Chart.yaml for helm chart '%s' ...", operator["name"])
             fillChartYaml(helmChart, operator["name"], csvPath)
             logging.info("Chart.yaml filled successfully.\n")

--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -14,7 +14,7 @@ import re
 from git import Repo, exc
 from packaging import version
 
-from validate_csv import *
+from helper import sync_owners_file
 
 # Configure logging with coloredlogs
 coloredlogs.install(level='DEBUG')  # Set the logging level as needed
@@ -363,6 +363,10 @@ def copyHelmChart(destinationChartPath, repo, chart, chartVersion, branch):
 
     shutil.copyfile(chartYamlPath, os.path.join(destinationChartPath, "Chart.yaml"))
     shutil.copyfile(os.path.join(chartPath, "values.yaml"), os.path.join(destinationChartPath, "values.yaml"))
+
+    # Sync OWNERS file from upstream repository root (upstream is single source of truth)
+    repo_root = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp", repo)
+    sync_owners_file(repo_root, destinationChartPath, chartName)
 
     # Copying template values.yaml instead of values.yaml from chart
     shutil.copyfile(os.path.join(os.path.dirname(os.path.realpath(__file__)), "chart-templates", "values.yaml"), os.path.join(destinationChartPath, "values.yaml"))
@@ -1379,6 +1383,10 @@ def addCRDs(repo, chart, outputDir):
             logging.info(f"Generated CRD file '{filename}'")
         else:
             logging.debug(f"Skipping file '{filename}' as it does not contain a CRD.")
+
+    # Sync OWNERS file from upstream repository root for CRDs (upstream is single source of truth)
+    repo_root = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp", repo)
+    sync_owners_file(repo_root, destinationCRDPath, f"{chart['name']} CRDs")
 
     logging.info(f"Finished processing CRDs for chart '{chart['name']}'\n")
 

--- a/scripts/bundle-generation/helper.py
+++ b/scripts/bundle-generation/helper.py
@@ -3,6 +3,8 @@
 # Copyright Contributors to the Open Cluster Management project
 # Assumes: Python 3.6+
 
+import os
+import shutil
 import sys
 import logging
 
@@ -25,3 +27,29 @@ def get_required_config_value(config, key, description=REQUIRED_BUNDLE_FIELD_DES
         )
         sys.exit(1)
     return value
+
+def sync_owners_file(repo_root_path, destination_chart_path, chart_name):
+    """
+    Syncs OWNERS file from upstream repository root to destination chart directory.
+    Upstream is the single source of truth:
+    - If upstream has OWNERS -> copy to destination
+    - If upstream has no OWNERS -> remove any existing downstream OWNERS
+
+    :param repo_root_path: Path to the root of the cloned upstream repository
+    :param destination_chart_path: Path to the destination chart directory
+    :param chart_name: Name of the chart (for logging)
+    """
+    upstream_owners = os.path.join(repo_root_path, "OWNERS")
+    dest_owners = os.path.join(destination_chart_path, "OWNERS")
+
+    if os.path.exists(upstream_owners):
+        # Upstream has OWNERS -> copy it
+        shutil.copyfile(upstream_owners, dest_owners)
+        logging.info(f"Copied OWNERS file from upstream repository root for chart: {chart_name}")
+    else:
+        # Upstream has no OWNERS -> remove any existing downstream OWNERS
+        if os.path.exists(dest_owners):
+            os.remove(dest_owners)
+            logging.info(f"Removed OWNERS file for chart '{chart_name}' (not present in upstream repository root)")
+        else:
+            logging.debug(f"No OWNERS file in upstream repository root for chart: {chart_name}, will fallback to root OWNERS")

--- a/scripts/bundle-generation/move-charts.py
+++ b/scripts/bundle-generation/move-charts.py
@@ -11,7 +11,7 @@ import logging
 import subprocess
 from git import Repo, exc
 
-from validate_csv import *
+from helper import sync_owners_file
 
 # Config Constants
 SCRIPT_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)))
@@ -62,6 +62,11 @@ def copyHelmChart(destinationChartPath, repo, chart):
         return
 
     shutil.copyfile(valuesYamlPath, os.path.join(destinationChartPath, "values.yaml"))
+
+    # Sync OWNERS file from upstream repository root (upstream is single source of truth)
+    repo_root = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp", repo)
+    sync_owners_file(repo_root, destinationChartPath, chartName)
+
     logging.info("Chart copied.\n")
 
 def addCRDs(repo, chart, outputDir):
@@ -92,7 +97,7 @@ def addCRDs(repo, chart, outputDir):
         shutil.rmtree(destinationPath)
     os.makedirs(destinationPath)
     for filename in os.listdir(crdPath):
-        if not filename.endswith(".yaml"): 
+        if not filename.endswith(".yaml"):
             continue
         filepath = os.path.join(crdPath, filename)
         with open(filepath, 'r') as f:
@@ -100,6 +105,10 @@ def addCRDs(repo, chart, outputDir):
 
         if resourceFile["kind"] == "CustomResourceDefinition":
             shutil.copyfile(filepath, os.path.join(destinationPath, filename))
+
+    # Sync OWNERS file from upstream repository root for CRDs (upstream is single source of truth)
+    repo_root = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp", repo)
+    sync_owners_file(repo_root, destinationPath, f"{chart['name']} CRDs")
 
 def chartConfigAcceptable(chart):
     helmChart = chart["name"]


### PR DESCRIPTION
## Summary

This PR enables component teams to add OWNERS files to their upstream chart/bundle repositories, which will be automatically synced to operator repositories (multiclusterhub-operator, backplane-operator) during chart regeneration. This allows component teams to independently approve changes to their charts without waiting for the Installer team.

## Changes

### Script Updates
- **generate-charts.py**: Sync OWNERS from upstream Helm chart repos
- **bundles-to-charts.py**: Sync OWNERS from upstream bundle repos  
- **move-charts.py**: Sync OWNERS from upstream Helm chart repos

### Behavior
All scripts now use **upstream as the single source of truth**:
- ✅ If upstream HAS OWNERS → copy to operator repository
- ✅ If upstream NO OWNERS → remove any existing downstream OWNERS (fallback to root OWNERS/Installer team)

### Documentation
Added `OWNERS_TEMPLATE.md` with:
- How OWNERS delegation works with Prow
- Where to place OWNERS files (Helm charts vs OLM bundles)
- YAML format and examples
- Approval behavior scenarios
- FAQ and rollout plan
- Applies to all operator repos (multiclusterhub-operator, backplane-operator)

## Benefits

- **Faster approvals**: Component teams don't need to wait for Installer team
- **Clear ownership**: Component teams have explicit responsibility for their charts
- **Flexibility**: Installer team can still approve when needed (Prow inheritance)
- **No drift**: Upstream is always the authoritative source
- **No duplication**: OWNERS maintained in component repos, auto-synced

## Example Flow

1. GRC team adds `OWNERS` file to `stolostron/governance-policy-propagator/deploy/chart/OWNERS`
2. Chart regeneration runs (cron job or manual) in multiclusterhub-operator
3. OWNERS copied to `multiclusterhub-operator/pkg/templates/charts/toggle/grc/OWNERS`
4. PR touching only GRC chart files → GRC team can `/approve` and merge

Same flow applies to backplane-operator and other repos using these scripts.

## Testing Plan

1. Merge this PR to installer-dev-tools
2. Component teams add OWNERS to their repos
3. Run chart regeneration in multiclusterhub-operator and backplane-operator
4. Verify OWNERS files sync correctly
5. Test PR approvals work as expected

## Related

- Discussed in context of enabling component team autonomy
- Follows Kubernetes/OpenShift OWNERS file patterns
- Applies to all operator repos using installer-dev-tools

/cc @cameronmwall @ngraham20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for upstream teams on managing OWNERS files in chart and bundle repositories, including placement, required approver/reviewer structure, Prow approval behavior, FAQ, and rollout plan.

* **Chores**
  * Enabled automatic synchronization of OWNERS into generated charts: upstream OWNERS are propagated downstream, absence upstream causes downstream OWNERS to be removed (falling back to root OWNERS), with documented approval and maintenance rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->