### PR TITLE
Fix probeConfig template checks to use hasKey

### DIFF
--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -1128,28 +1128,22 @@ def inject_probe_config_helm_templates(deployment_file):
             if 'exec:' in probe_text:
                 # Append missing fields
                 if 'timeoutSeconds:' not in probe_text:
-                    lines.insert(j, '{{- if .Values.hubconfig.probeConfig }}\n')
-                    lines.insert(j+1, '{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}\n')
-                    lines.insert(j+2, f'{field_indent}timeoutSeconds: {{{{ .Values.hubconfig.probeConfig.timeoutSeconds }}}}\n')
-                    lines.insert(j+3, '{{- end }}\n')
-                    lines.insert(j+4, '{{- end }}\n')
-                    j += 5
+                    lines.insert(j, '{{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "timeoutSeconds") }}\n')
+                    lines.insert(j+1, f'{field_indent}timeoutSeconds: {{{{ .Values.hubconfig.probeConfig.timeoutSeconds }}}}\n')
+                    lines.insert(j+2, '{{- end }}\n')
+                    j += 3
 
                 if 'failureThreshold:' not in probe_text:
-                    lines.insert(j, '{{- if .Values.hubconfig.probeConfig }}\n')
-                    lines.insert(j+1, '{{- if .Values.hubconfig.probeConfig.failureThreshold }}\n')
-                    lines.insert(j+2, f'{field_indent}failureThreshold: {{{{ .Values.hubconfig.probeConfig.failureThreshold }}}}\n')
-                    lines.insert(j+3, '{{- end }}\n')
-                    lines.insert(j+4, '{{- end }}\n')
-                    j += 5
+                    lines.insert(j, '{{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "failureThreshold") }}\n')
+                    lines.insert(j+1, f'{field_indent}failureThreshold: {{{{ .Values.hubconfig.probeConfig.failureThreshold }}}}\n')
+                    lines.insert(j+2, '{{- end }}\n')
+                    j += 3
 
                 if 'successThreshold:' not in probe_text:
-                    lines.insert(j, '{{- if .Values.hubconfig.probeConfig }}\n')
-                    lines.insert(j+1, '{{- if .Values.hubconfig.probeConfig.successThreshold }}\n')
-                    lines.insert(j+2, f'{field_indent}successThreshold: {{{{ .Values.hubconfig.probeConfig.successThreshold }}}}\n')
-                    lines.insert(j+3, '{{- end }}\n')
-                    lines.insert(j+4, '{{- end }}\n')
-                    j += 5
+                    lines.insert(j, '{{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "successThreshold") }}\n')
+                    lines.insert(j+1, f'{field_indent}successThreshold: {{{{ .Values.hubconfig.probeConfig.successThreshold }}}}\n')
+                    lines.insert(j+2, '{{- end }}\n')
+                    j += 3
 
             i = j
         else:

--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -710,28 +710,22 @@ def inject_probe_config_helm_templates(deployment_file):
             if 'exec:' in probe_text:
                 # Append missing fields
                 if 'timeoutSeconds:' not in probe_text:
-                    lines.insert(j, '{{- if .Values.hubconfig.probeConfig }}\n')
-                    lines.insert(j+1, '{{- if .Values.hubconfig.probeConfig.timeoutSeconds }}\n')
-                    lines.insert(j+2, f'{field_indent}timeoutSeconds: {{{{ .Values.hubconfig.probeConfig.timeoutSeconds }}}}\n')
-                    lines.insert(j+3, '{{- end }}\n')
-                    lines.insert(j+4, '{{- end }}\n')
-                    j += 5
+                    lines.insert(j, '{{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "timeoutSeconds") }}\n')
+                    lines.insert(j+1, f'{field_indent}timeoutSeconds: {{{{ .Values.hubconfig.probeConfig.timeoutSeconds }}}}\n')
+                    lines.insert(j+2, '{{- end }}\n')
+                    j += 3
 
                 if 'failureThreshold:' not in probe_text:
-                    lines.insert(j, '{{- if .Values.hubconfig.probeConfig }}\n')
-                    lines.insert(j+1, '{{- if .Values.hubconfig.probeConfig.failureThreshold }}\n')
-                    lines.insert(j+2, f'{field_indent}failureThreshold: {{{{ .Values.hubconfig.probeConfig.failureThreshold }}}}\n')
-                    lines.insert(j+3, '{{- end }}\n')
-                    lines.insert(j+4, '{{- end }}\n')
-                    j += 5
+                    lines.insert(j, '{{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "failureThreshold") }}\n')
+                    lines.insert(j+1, f'{field_indent}failureThreshold: {{{{ .Values.hubconfig.probeConfig.failureThreshold }}}}\n')
+                    lines.insert(j+2, '{{- end }}\n')
+                    j += 3
 
                 if 'successThreshold:' not in probe_text:
-                    lines.insert(j, '{{- if .Values.hubconfig.probeConfig }}\n')
-                    lines.insert(j+1, '{{- if .Values.hubconfig.probeConfig.successThreshold }}\n')
-                    lines.insert(j+2, f'{field_indent}successThreshold: {{{{ .Values.hubconfig.probeConfig.successThreshold }}}}\n')
-                    lines.insert(j+3, '{{- end }}\n')
-                    lines.insert(j+4, '{{- end }}\n')
-                    j += 5
+                    lines.insert(j, '{{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "successThreshold") }}\n')
+                    lines.insert(j+1, f'{field_indent}successThreshold: {{{{ .Values.hubconfig.probeConfig.successThreshold }}}}\n')
+                    lines.insert(j+2, '{{- end }}\n')
+                    j += 3
 
             i = j
         else:


### PR DESCRIPTION
# Description

Fixes "map has no entry for key" errors in Helm template rendering when probeConfig has partial fields set. Replaces nested if statements with hasKey checks in probe configuration injection.

## Related Issue

Related to multiclusterhub-operator work on probe annotation support. Prevents template rendering failures when users set only timeoutSeconds without failureThreshold/successThreshold.

## Changes Made

**bundles-to-charts.py:**
- Updated `inject_probe_config_helm_templates` to use `hasKey` checks instead of nested if statements
- Changed from 5-line blocks to 3-line blocks per field

**generate-charts.py:**
- Updated `inject_probe_config_helm_templates` to use `hasKey` checks instead of nested if statements
- Changed from 5-line blocks to 3-line blocks per field

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This fixes a bug introduced in #141 where nested if statements caused template rendering to fail with "map has no entry for key" when probeConfig was partially populated.

Example failure scenario:
```yaml
hubconfig:
  probeConfig:
    timeoutSeconds: 30
```

Old template would fail evaluating `.Values.hubconfig.probeConfig.failureThreshold` because the key doesn't exist.

New template checks `hasKey` before accessing, preventing the error.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.