### PR TITLE
fix: correct nested path handling for MulticlusterRoleAssignment namespaces

### DIFF
--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -877,7 +877,7 @@ def ensure_managedclustersetbinding_namespace(resource_data, resource_name, defa
     if 'metadata' not in resource_data:
         # this would cause a lot of problems
         return
-    
+
     mcsb_metadata = resource_data['metadata']
     mcsb_namespace = mcsb_metadata.get('namespace', default_namespace)
 
@@ -886,6 +886,42 @@ def ensure_managedclustersetbinding_namespace(resource_data, resource_name, defa
         mcsb_namespace = f"{{{{ default \"{mcsb_namespace}\" .Values.global.namespace }}}}"
         mcsb_metadata['namespace'] = mcsb_namespace
         logging.info(f"Namespace for ManagedClusterSetBinding {resource_name} set to {mcsb_namespace}")
+
+def ensure_multiclusterroleassignment_namespace(resource_data, resource_name, default_namespace):
+    """
+    Ensures that namespace references in MulticlusterRoleAssignment subject and placements are templated.
+
+    Note: metadata.namespace is already handled by the generic namespace-scoped resource logic
+    before this function is called. This function only handles subject.namespace and placements[].namespace.
+
+    If namespace fields are set to 'open-cluster-management', they are wrapped in a Helm
+    `default` function to allow overriding via `.Values.global.namespace`.
+
+    Args:
+        resource_data (dict): The MulticlusterRoleAssignment resource data dictionary.
+        resource_name (str): The name of the MulticlusterRoleAssignment resource.
+        default_namespace (str): The default namespace template to use.
+
+    Returns:
+        None: Modifies resource_data in place.
+    """
+    # Handle subject.namespace
+    if 'subject' in resource_data:
+        subject = resource_data['subject']
+        subject_namespace = subject.get('namespace', default_namespace)
+        if subject_namespace == 'open-cluster-management':
+            subject_namespace = f"{{{{ default \"{subject_namespace}\" .Values.global.namespace }}}}"
+            subject['namespace'] = subject_namespace
+            logging.info(f"Namespace for MulticlusterRoleAssignment {resource_name} subject set to {subject_namespace}")
+
+    # Handle placements[].namespace
+    if 'placements' in resource_data:
+        for placement in resource_data['placements']:
+            placement_namespace = placement.get('namespace', default_namespace)
+            if placement_namespace == 'open-cluster-management':
+                placement_namespace = f"{{{{ default \"{placement_namespace}\" .Values.global.namespace }}}}"
+                placement['namespace'] = placement_namespace
+                logging.info(f"Namespace for MulticlusterRoleAssignment {resource_name} placement '{placement.get('name')}' set to {placement_namespace}")
 
 def ensure_clustermanagementaddon_namespace(resource_data, resource_name, default_namespace):
     if 'spec' not in resource_data:
@@ -1027,12 +1063,12 @@ def update_helm_resources(chartName, helmChart, skip_rbac_overrides, exclusions,
 
     resource_kinds = [
         "AddOnTemplate", "Certificate", "ClusterManagementAddOn", "ClusterRole", "ClusterRoleBinding", "ConfigMap", "ConsolePlugin", "Deployment", "Issuer", "Job",
-        "ManagedClusterSetBinding", "MutatingWebhookConfiguration", "NetworkPolicy", "PersistentVolumeClaim", "Placement", "PodDisruptionBudget", "Role", "RoleBinding",
+        "ManagedClusterSetBinding", "MulticlusterRoleAssignment", "MutatingWebhookConfiguration", "NetworkPolicy", "PersistentVolumeClaim", "Placement", "PodDisruptionBudget", "Role", "RoleBinding",
         "Route", "Secret", "Service", "StatefulSet", "ValidatingWebhookConfiguration",
     ]
 
     namespace_scoped_kinds = [
-        "Certificate", "ConfigMap", "Deployment", "Issuer", "Job", "ManagedClusterSetBinding", "NetworkPolicy", "PersistentVolumeClaim", "Placement",
+        "Certificate", "ConfigMap", "Deployment", "Issuer", "Job", "ManagedClusterSetBinding", "MulticlusterRoleAssignment", "NetworkPolicy", "PersistentVolumeClaim", "Placement",
         "PodDisruptionBudget", "Role", "RoleBinding", "Route", "Secret", "Service", "StatefulSet"
     ]
 
@@ -1100,7 +1136,12 @@ def update_helm_resources(chartName, helmChart, skip_rbac_overrides, exclusions,
                 # defaulting to Helm values if not specified.
                 if kind == 'ManagedClusterSetBinding':
                     ensure_managedclustersetbinding_namespace(resource_data, resource_name, default_namespace)
-                
+
+                # Ensure MulticlusterRoleAssignment has namespace set for metadata, subject, and placements,
+                # defaulting to Helm values if not specified.
+                if kind == 'MulticlusterRoleAssignment':
+                    ensure_multiclusterroleassignment_namespace(resource_data, resource_name, default_namespace)
+
                 # Ensure Placement has namespace set for open-cluster-management references,
                 # defaulting to Helm values if not specified.
                 if kind == 'Placement':

--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -892,7 +892,8 @@ def ensure_multiclusterroleassignment_namespace(resource_data, resource_name, de
     Ensures that namespace references in MulticlusterRoleAssignment subject and placements are templated.
 
     Note: metadata.namespace is already handled by the generic namespace-scoped resource logic
-    before this function is called. This function only handles subject.namespace and placements[].namespace.
+    before this function is called. This function only handles spec.subject.namespace and
+    spec.roleAssignments[].clusterSelection.placements[].namespace.
 
     If namespace fields are set to 'open-cluster-management', they are wrapped in a Helm
     `default` function to allow overriding via `.Values.global.namespace`.
@@ -905,23 +906,34 @@ def ensure_multiclusterroleassignment_namespace(resource_data, resource_name, de
     Returns:
         None: Modifies resource_data in place.
     """
-    # Handle subject.namespace
-    if 'subject' in resource_data:
-        subject = resource_data['subject']
+    if 'spec' not in resource_data:
+        return
+
+    spec = resource_data['spec']
+
+    # Handle spec.subject.namespace
+    if 'subject' in spec:
+        subject = spec['subject']
         subject_namespace = subject.get('namespace', default_namespace)
         if subject_namespace == 'open-cluster-management':
             subject_namespace = f"{{{{ default \"{subject_namespace}\" .Values.global.namespace }}}}"
             subject['namespace'] = subject_namespace
             logging.info(f"Namespace for MulticlusterRoleAssignment {resource_name} subject set to {subject_namespace}")
 
-    # Handle placements[].namespace
-    if 'placements' in resource_data:
-        for placement in resource_data['placements']:
-            placement_namespace = placement.get('namespace', default_namespace)
-            if placement_namespace == 'open-cluster-management':
-                placement_namespace = f"{{{{ default \"{placement_namespace}\" .Values.global.namespace }}}}"
-                placement['namespace'] = placement_namespace
-                logging.info(f"Namespace for MulticlusterRoleAssignment {resource_name} placement '{placement.get('name')}' set to {placement_namespace}")
+    # Handle spec.roleAssignments[].clusterSelection.placements[].namespace
+    if 'roleAssignments' in spec:
+        for role_assignment in spec['roleAssignments']:
+            if 'clusterSelection' not in role_assignment:
+                continue
+            cluster_selection = role_assignment['clusterSelection']
+            if 'placements' not in cluster_selection:
+                continue
+            for placement in cluster_selection['placements']:
+                placement_namespace = placement.get('namespace', default_namespace)
+                if placement_namespace == 'open-cluster-management':
+                    placement_namespace = f"{{{{ default \"{placement_namespace}\" .Values.global.namespace }}}}"
+                    placement['namespace'] = placement_namespace
+                    logging.info(f"Namespace for MulticlusterRoleAssignment {resource_name} placement '{placement.get('name')}' set to {placement_namespace}")
 
 def ensure_clustermanagementaddon_namespace(resource_data, resource_name, default_namespace):
     if 'spec' not in resource_data:


### PR DESCRIPTION
# Description

Fixes namespace template reversion in MulticlusterRoleAssignment resources by correcting the field paths checked by the ensure function.

## Related Issue

Follow-up fix to #159 - addresses why stolostron/multiclusterhub-operator#4268 still showed namespace reversion after initial fix merged.

## Changes Made

**Problem:** Previous implementation checked wrong paths in MulticlusterRoleAssignment structure:
- Checked `subject.namespace` instead of `spec.subject.namespace`
- Checked `placements[].namespace` instead of `spec.roleAssignments[].clusterSelection.placements[].namespace`

This caused the function to never match the actual resource structure, so namespace templates continued reverting to hardcoded values.

**Fix:**
- Updated `ensure_multiclusterroleassignment_namespace()` to handle correct nested paths:
  - `spec.subject.namespace`
  - `spec.roleAssignments[].clusterSelection.placements[].namespace`
- Added iteration through `roleAssignments` array and `clusterSelection.placements` array
- Updated docstring to reflect actual structure

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This explains why the automated regenerate-chart PR still showed namespace reversion even after the initial fix was merged. The function was never executing because it was checking paths that don't exist in the actual MulticlusterRoleAssignment structure.

## Reviewers

/cc @dislbenn

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Helm chart generation now correctly handles namespace references for multicluster role assignment resources.
  * Namespace values are now safely overridden during templating when they match the default shared namespace, helping generated charts work in more environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->