### PR TITLE
Add NetworkPolicy helm conditional wrapping to chart generation

### DIFF
--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -764,6 +764,32 @@ def update_helm_resources(chartName, helmChart, skip_rbac_overrides, exclusions,
 
     logging.info("Resource updating process completed.")
 
+
+def wrapNetworkPoliciesWithCondition(helmChart, branch):
+    """Wraps NetworkPolicy templates with a Helm conditional so they are only
+    deployed when global.networkPolicies.enabled is true.
+
+    Args:
+        helmChart: Path to the Helm chart directory
+        branch: Branch name for version compatibility checks
+    """
+    logging.info("Wrapping NetworkPolicy templates with networkPolicies.enabled condition ...")
+    networkPolicyTemplates = find_templates_of_type(helmChart, "NetworkPolicy", branch)
+    for template_path in networkPolicyTemplates:
+        f = open(template_path, "r")
+        content = f.read()
+        f.close()
+        if '{{- if .Values.global.networkPolicies.enabled }}' not in content:
+            if not content.endswith('\n'):
+                content += '\n'
+            wrapped = '{{- if .Values.global.networkPolicies.enabled }}\n' + content + '{{- end }}\n'
+            a_file = open(template_path, "w")
+            a_file.write(wrapped)
+            a_file.close()
+            logging.info("Wrapped NetworkPolicy template: %s", template_path)
+    logging.info("NetworkPolicy wrapping complete.\n")
+
+
 # Given a resource Kind, return all filepaths of that resource type in a chart directory
 def find_templates_of_type(helmChart, kind, branch):
     """_summary_
@@ -1435,6 +1461,8 @@ def injectRequirements(helm_chart_path, operator, sizes, branch):
     # Updates RBAC and deployment configuration in the Helm chart.
     updateRBAC(helm_chart_path, branch)
     updateDeployments(helm_chart_path, operator, exclusions, sizes, branch)
+
+    wrapNetworkPoliciesWithCondition(helm_chart_path, branch)
 
     logging.info("Updated Chart '%s' successfully\n", helm_chart_path)
     return []

--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -1246,6 +1246,25 @@ def update_helm_resources(chartName, helmChart, skip_rbac_overrides, exclusions,
 
     logging.info("Resource updating process completed.")
 
+
+def wrapNetworkPoliciesWithCondition(helmChart):
+    logging.info("Wrapping NetworkPolicy templates with networkPolicies.enabled condition ...")
+    networkPolicyTemplates = find_templates_of_type(helmChart, "NetworkPolicy")
+    for template_path in networkPolicyTemplates:
+        f = open(template_path, "r")
+        content = f.read()
+        f.close()
+        if '{{- if .Values.global.networkPolicies.enabled }}' not in content:
+            if not content.endswith('\n'):
+                content += '\n'
+            wrapped = '{{- if .Values.global.networkPolicies.enabled }}\n' + content + '{{- end }}\n'
+            a_file = open(template_path, "w")
+            a_file.write(wrapped)
+            a_file.close()
+            logging.info("Wrapped NetworkPolicy template: %s", template_path)
+    logging.info("NetworkPolicy wrapping complete.\n")
+
+
 # injectAnnotationsForAddonTemplate injects following annotations for deployments in the AddonTemplate:
 # - target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 def injectAnnotationsForAddonTemplate(helmChart):
@@ -1465,6 +1484,8 @@ def injectRequirements(helm_chart_path, chart, branch):
         update_helm_resources(chart_name, helm_chart_path, skip_rbac_overrides, exclusions, inclusions, branch)
 
     updateDeployments(chart_name, helm_chart_path, exclusions, inclusions, branch)
+
+    wrapNetworkPoliciesWithCondition(helm_chart_path)
 
     logging.info("Updated Chart '%s' successfully", helm_chart_path)
 


### PR DESCRIPTION
## Summary
- Add `wrapNetworkPoliciesWithCondition` function to `generate-charts.py` and `bundles-to-charts.py`
- Wraps generated NetworkPolicy templates with `{{- if .Values.global.networkPolicies.enabled }}` / `{{- end }}`
- Runs after all other template processing in `injectRequirements` to avoid interfering with YAML parsing steps
- Idempotent — skips files already wrapped

## Context
Automated chart regeneration was stripping the `networkPolicies.enabled` conditional from NetworkPolicy templates. This ensures all generated NetworkPolicy resources are gated behind the flag, matching the existing pattern used in hand-maintained templates (e.g. hypershift-addon-manager-networkpolicy.yaml).

Companion PRs:
- stolostron/backplane-operator#3695
- stolostron/multiclusterhub-operator#4451

## Test plan
- [ ] Run `make regenerate-charts` in backplane-operator and verify NetworkPolicy templates have the `{{- if }}` wrapper
- [ ] Run `make regenerate-charts-from-bundles` and verify same
- [ ] Verify idempotency — running twice doesn't double-wrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)