### PR TITLE
fix: inline NetworkPolicy wrapping into update_helm_resources loop

### DIFF
--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -759,35 +759,32 @@ def update_helm_resources(chartName, helmChart, skip_rbac_overrides, exclusions,
                     yaml.dump(resource_data, f, width=float("inf"), default_flow_style=False, allow_unicode=True)
                     logging.info(f"Succesfully updated resource: {resource_name}\n")
 
+                # Ensure NetworkPolicy templates are wrapped with a Helm conditional to only deploy when enabled.
+                if kind == 'NetworkPolicy':
+                    ensure_network_policies(template_path)
+
             except Exception as e:
                 logging.error(f"Error processing template '{template_path}': {e}")
 
     logging.info("Resource updating process completed.")
 
 
-def wrapNetworkPoliciesWithCondition(helmChart, branch):
-    """Wraps NetworkPolicy templates with a Helm conditional so they are only
-    deployed when global.networkPolicies.enabled is true.
-
-    Args:
-        helmChart: Path to the Helm chart directory
-        branch: Branch name for version compatibility checks
-    """
-    logging.info("Wrapping NetworkPolicy templates with networkPolicies.enabled condition ...")
-    networkPolicyTemplates = find_templates_of_type(helmChart, "NetworkPolicy", branch)
-    for template_path in networkPolicyTemplates:
-        f = open(template_path, "r")
+def ensure_network_policies(template_path):
+    """Wraps a NetworkPolicy template with a Helm conditional so it is only
+    deployed when global.networkPolicies.enabled is true."""
+    with open(template_path, "r") as f:
         content = f.read()
-        f.close()
-        if '{{- if .Values.global.networkPolicies.enabled }}' not in content:
-            if not content.endswith('\n'):
-                content += '\n'
-            wrapped = '{{- if .Values.global.networkPolicies.enabled }}\n' + content + '{{- end }}\n'
-            a_file = open(template_path, "w")
-            a_file.write(wrapped)
-            a_file.close()
-            logging.info("Wrapped NetworkPolicy template: %s", template_path)
-    logging.info("NetworkPolicy wrapping complete.\n")
+    if '{{- if .Values.global.networkPolicies.enabled }}' in content:
+        return
+
+    if not content.endswith('\n'):
+        content += '\n'
+
+    wrapped = '{{- if .Values.global.networkPolicies.enabled }}\n' + content + '{{- end }}\n'
+    with open(template_path, "w") as f:
+        f.write(wrapped)
+
+    logging.info("Wrapped NetworkPolicy template with networkPolicies.enabled condition: %s", template_path)
 
 
 # Given a resource Kind, return all filepaths of that resource type in a chart directory
@@ -1461,8 +1458,6 @@ def injectRequirements(helm_chart_path, operator, sizes, branch):
     # Updates RBAC and deployment configuration in the Helm chart.
     updateRBAC(helm_chart_path, branch)
     updateDeployments(helm_chart_path, operator, exclusions, sizes, branch)
-
-    wrapNetworkPoliciesWithCondition(helm_chart_path, branch)
 
     logging.info("Updated Chart '%s' successfully\n", helm_chart_path)
     return []

--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -709,6 +709,8 @@ def update_helm_resources(chartName, helmChart, skip_rbac_overrides, exclusions,
         "Secret", "Service", "StatefulSet", "Job"
     ]
 
+    network_policy_templates = []
+
     for kind in resource_kinds:
         resource_templates = find_templates_of_type(helmChart, kind, branch)
         if not resource_templates:
@@ -759,12 +761,16 @@ def update_helm_resources(chartName, helmChart, skip_rbac_overrides, exclusions,
                     yaml.dump(resource_data, f, width=float("inf"), default_flow_style=False, allow_unicode=True)
                     logging.info(f"Succesfully updated resource: {resource_name}\n")
 
-                # Ensure NetworkPolicy templates are wrapped with a Helm conditional to only deploy when enabled.
                 if kind == 'NetworkPolicy':
-                    ensure_network_policies(template_path)
+                    network_policy_templates.append(template_path)
 
             except Exception as e:
                 logging.error(f"Error processing template '{template_path}': {e}")
+
+    # Ensure NetworkPolicy templates are wrapped with a Helm conditional to only deploy when enabled.
+    # Done after all kinds are processed to avoid breaking yaml.safe_load for subsequent kind iterations.
+    for template_path in network_policy_templates:
+        ensure_network_policies(template_path)
 
     logging.info("Resource updating process completed.")
 

--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -1084,6 +1084,8 @@ def update_helm_resources(chartName, helmChart, skip_rbac_overrides, exclusions,
         "PodDisruptionBudget", "Role", "RoleBinding", "Route", "Secret", "Service", "StatefulSet"
     ]
 
+    network_policy_templates = []
+
     for kind in resource_kinds:
         resource_templates = find_templates_of_type(helmChart, kind)
         if not resource_templates:
@@ -1179,10 +1181,6 @@ def update_helm_resources(chartName, helmChart, skip_rbac_overrides, exclusions,
                 if kind == 'PersistentVolumeClaim':
                     ensure_pvc_storage_class(resource_data, resource_name)
                 
-                # Ensure NetworkPolicy templates are wrapped with a Helm conditional to only deploy when enabled.
-                if kind == 'NetworkPolicy':
-                    ensure_network_policies(template_path)
-
                 if chartName == 'flight-control':
                     if kind == 'Route':
                         if resource_name == 'flightctl-api-route':
@@ -1244,8 +1242,16 @@ def update_helm_resources(chartName, helmChart, skip_rbac_overrides, exclusions,
                     yaml.dump(resource_data, f, width=float("inf"), default_flow_style=False, allow_unicode=True)
                     logging.info(f"Succesfully updated resource: {resource_name}\n")
 
+                if kind == 'NetworkPolicy':
+                    network_policy_templates.append(template_path)
+
             except Exception as e:
                 logging.error(f"Error processing template '{template_path}': {e}")
+
+    # Ensure NetworkPolicy templates are wrapped with a Helm conditional to only deploy when enabled.
+    # Done after all kinds are processed to avoid breaking yaml.safe_load for subsequent kind iterations.
+    for template_path in network_policy_templates:
+        ensure_network_policies(template_path)
 
     logging.info("Resource updating process completed.")
 

--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -1179,6 +1179,9 @@ def update_helm_resources(chartName, helmChart, skip_rbac_overrides, exclusions,
                 if kind == 'PersistentVolumeClaim':
                     ensure_pvc_storage_class(resource_data, resource_name)
                 
+                # Ensure NetworkPolicy templates are wrapped with a Helm conditional to only deploy when enabled.
+                if kind == 'NetworkPolicy':
+                    ensure_network_policies(template_path)
 
                 if chartName == 'flight-control':
                     if kind == 'Route':
@@ -1247,22 +1250,22 @@ def update_helm_resources(chartName, helmChart, skip_rbac_overrides, exclusions,
     logging.info("Resource updating process completed.")
 
 
-def wrapNetworkPoliciesWithCondition(helmChart):
-    logging.info("Wrapping NetworkPolicy templates with networkPolicies.enabled condition ...")
-    networkPolicyTemplates = find_templates_of_type(helmChart, "NetworkPolicy")
-    for template_path in networkPolicyTemplates:
-        f = open(template_path, "r")
+def ensure_network_policies(template_path):
+    """Wraps a NetworkPolicy template with a Helm conditional so it is only
+    deployed when global.networkPolicies.enabled is true."""
+    with open(template_path, "r") as f:
         content = f.read()
-        f.close()
-        if '{{- if .Values.global.networkPolicies.enabled }}' not in content:
-            if not content.endswith('\n'):
-                content += '\n'
-            wrapped = '{{- if .Values.global.networkPolicies.enabled }}\n' + content + '{{- end }}\n'
-            a_file = open(template_path, "w")
-            a_file.write(wrapped)
-            a_file.close()
-            logging.info("Wrapped NetworkPolicy template: %s", template_path)
-    logging.info("NetworkPolicy wrapping complete.\n")
+    if '{{- if .Values.global.networkPolicies.enabled }}' in content:
+        return
+
+    if not content.endswith('\n'):
+        content += '\n'
+
+    wrapped = '{{- if .Values.global.networkPolicies.enabled }}\n' + content + '{{- end }}\n'
+    with open(template_path, "w") as f:
+        f.write(wrapped)
+
+    logging.info("Wrapped NetworkPolicy template with networkPolicies.enabled condition: %s", template_path)
 
 
 # injectAnnotationsForAddonTemplate injects following annotations for deployments in the AddonTemplate:
@@ -1484,8 +1487,6 @@ def injectRequirements(helm_chart_path, chart, branch):
         update_helm_resources(chart_name, helm_chart_path, skip_rbac_overrides, exclusions, inclusions, branch)
 
     updateDeployments(chart_name, helm_chart_path, exclusions, inclusions, branch)
-
-    wrapNetworkPoliciesWithCondition(helm_chart_path)
 
     logging.info("Updated Chart '%s' successfully", helm_chart_path)
 


### PR DESCRIPTION
# Description

Fixes CI crash in backplane-operator's `regenerate-charts` workflow caused by `wrapNetworkPoliciesWithCondition` calling `find_templates_of_type`, which scans all YAML templates and crashes on Helm-templated files (e.g. cluster-api deployment) that `yaml.safe_load` cannot parse.

## Related Issue

https://github.com/stolostron/backplane-operator/actions/runs/29943478413/job/89002932380

## Changes Made

- Replaced standalone `wrapNetworkPoliciesWithCondition` with `ensure_network_policies(template_path)` — a single-file function called inline from the existing `update_helm_resources` kind loop
- NetworkPolicy templates are now discovered through the same `find_templates_of_type` scan as all other resource kinds (Deployment, ClusterRole, etc.), eliminating a redundant full-directory scan
- Applied consistently to both `generate-charts.py` and `bundles-to-charts.py`

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

- Tested locally with `make regenerate-charts` and `make regenerate-charts-from-bundles` against backplane-operator — both passed
- The `ensure_network_policies` function follows the same pattern as `ensure_pvc_storage_class`, `ensure_stateful_set_storage_class`, etc.

## Reviewers

/cc @cameronmwall

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm chart generation now conditionally includes NetworkPolicy resources based on `global.networkPolicies.enabled`.
* **Bug Fixes**
  * NetworkPolicy templates are wrapped only once, preventing duplicate condition blocks.
  * Improved consistency and reliability of generated charts when network policy support is toggled on or off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->