### PR TITLE
Add NetworkPolicy wrapping for AddOnTemplate manifests

### DIFF
--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -1277,6 +1277,58 @@ def ensure_network_policies(template_path):
     logging.info("Wrapped NetworkPolicy template with networkPolicies.enabled condition: %s", template_path)
 
 
+def ensure_addontemplate_network_policies(helmChart):
+    """Wraps NetworkPolicy manifests embedded inside AddOnTemplate resources
+    with a Helm conditional so they are only deployed when
+    global.networkPolicies.enabled is true."""
+    addonTemplates = find_templates_of_type(helmChart, 'AddOnTemplate')
+    for addonTemplate in addonTemplates:
+        with open(addonTemplate, 'r') as f:
+            content = f.read()
+
+        if 'kind: NetworkPolicy' not in content:
+            continue
+
+        if '{{- if .Values.global.networkPolicies.enabled }}' in content:
+            continue
+
+        lines = content.split('\n')
+        result = []
+        i = 0
+        while i < len(lines):
+            if (i + 1 < len(lines) and
+                'apiVersion: networking.k8s.io/v1' in lines[i] and
+                lines[i].lstrip().startswith('- apiVersion:') and
+                'kind: NetworkPolicy' in lines[i + 1]):
+
+                indent = lines[i][:len(lines[i]) - len(lines[i].lstrip())]
+
+                result.append(f'{indent}{{{{- if .Values.global.networkPolicies.enabled }}}}')
+                result.append(lines[i])
+                i += 1
+
+                item_prefix = indent + '- '
+                continuation_indent = indent + '  '
+                while i < len(lines):
+                    if lines[i] == '':
+                        result.append(lines[i])
+                        i += 1
+                        continue
+                    if lines[i].startswith(item_prefix) or (lines[i].strip() and not lines[i].startswith(continuation_indent)):
+                        break
+                    result.append(lines[i])
+                    i += 1
+
+                result.append(f'{indent}{{{{- end }}}}')
+            else:
+                result.append(lines[i])
+                i += 1
+
+        with open(addonTemplate, 'w') as f:
+            f.write('\n'.join(result))
+        logging.info("Wrapped NetworkPolicy in AddOnTemplate with networkPolicies.enabled condition: %s", addonTemplate)
+
+
 # injectAnnotationsForAddonTemplate injects following annotations for deployments in the AddonTemplate:
 # - target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 def injectAnnotationsForAddonTemplate(helmChart):
@@ -1485,6 +1537,7 @@ def injectRequirements(helm_chart_path, chart, branch):
     fixEnvVarImageReferences(helm_chart_path, image_mappings)
     fixImageReferencesForAddonTemplate(helm_chart_path, image_mappings)
     injectAnnotationsForAddonTemplate(helm_chart_path)
+    ensure_addontemplate_network_policies(helm_chart_path)
 
     if not skip_rbac_overrides:
         updateRBAC(helm_chart_path, chart_name)


### PR DESCRIPTION
# Description

`ensure_network_policies()` only wraps standalone NetworkPolicy YAML files with `{{- if .Values.global.networkPolicies.enabled }}`. NetworkPolicies embedded inside AddOnTemplate `spec.agentSpec.workload.manifests[]` are missed because they share a file with the parent AddOnTemplate resource.

## Related Issue

- https://github.com/stolostron/backplane-operator/pull/3731

## Changes Made

- Added `ensure_addontemplate_network_policies()` function that scans AddOnTemplate files for embedded NetworkPolicy manifests and wraps each one with the `{{- if .Values.global.networkPolicies.enabled }}` / `{{- end }}` conditional.
- Called in `injectRequirements()` after `injectAnnotationsForAddonTemplate()`.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Tested by running `make regenerate-charts COMPONENT=managed-serviceaccount` from backplane-operator. The generated `managed-serviceaccount-addontemplate.yaml` correctly has the NetworkPolicy block wrapped with `{{- if .Values.global.networkPolicies.enabled }}` / `{{- end }}` while other manifests (Deployment, Service, Role, etc.) remain unaffected.

## Reviewers

/cc @dislbenn

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedded network policies in add-on templates can now be enabled or disabled using the global network policy setting.
  * Chart generation consistently applies network policy controls to both top-level and embedded resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->