### PR TITLE
Make addCRDs() resilient to unparseable manifests, and use shallow clones

### DIFF
--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -2019,14 +2019,6 @@ def main():
             else:
                 git_url = github_ref
 
-            logging.info("Cloning repository: %s from %s", repo_name, git_url)
-            repo_path = os.path.join(SCRIPT_DIR, "tmp", repo_name)
-
-            if os.path.exists(repo_path):
-                shutil.rmtree(repo_path)
-
-            repository = Repo.clone_from(git_url, repo_path)
-
             # Check for branch override first, then use config branch
             if repo_name in component_branch_overrides:
                 branch_to_use = component_branch_overrides[repo_name]
@@ -2034,7 +2026,16 @@ def main():
             else:
                 branch_to_use = branch
 
-            repository.git.checkout(branch_to_use)
+            logging.info("Cloning repository: %s from %s (branch=%s)", repo_name, git_url, branch_to_use)
+            repo_path = os.path.join(SCRIPT_DIR, "tmp", repo_name)
+
+            if os.path.exists(repo_path):
+                shutil.rmtree(repo_path)
+
+            # Shallow, single-branch clone: only the tip commit of the target
+            # branch is needed, since this script only reads current file
+            # contents (CSVs/CRDs/manifests) and never inspects history.
+            Repo.clone_from(git_url, repo_path, branch=branch_to_use, depth=1)
 
             sizesyaml = repo_path + "/bundle/manifests/sizes.yaml"
             if os.path.isfile(sizesyaml):

--- a/scripts/bundle-generation/bundles-to-charts.py
+++ b/scripts/bundle-generation/bundles-to-charts.py
@@ -1473,6 +1473,22 @@ def addCRDs(repo, operator, outputDir, branch, preservedFiles=None, overwrite=Fa
     """
     Add Custom Resource Definitions (CRDs) to the specified output directory.
 
+    Every ".yaml" file in the bundle's manifests directory is inspected for a
+    CustomResourceDefinition, since CRD files are not guaranteed to follow any
+    particular naming convention across upstream repos. Files that cannot be
+    parsed as plain YAML (for example, bundle manifests that embed Helm/Go
+    template syntax) are skipped rather than aborting the whole run.
+
+    Skipped files are logged with an "UNPARSEABLE_MANIFEST:" prefix so callers
+    (e.g. CI) can grep for exactly this condition without matching the many
+    unrelated INFO/WARNING log lines this script already emits. This is
+    intentionally non-fatal: it does not raise and is not added to any error
+    list that would fail the run, so a single malformed file in one upstream
+    repo can't block chart generation for every other component in the same
+    run. Downstream automation is expected to surface these to a human (e.g.
+    in the body of an automatically opened PR) for manual verification rather
+    than silently dropping a file that may have been a real CRD.
+
     Args:
         repo (str): The name of the repository.
         operator (dict): The configuration of the operator.
@@ -1481,10 +1497,18 @@ def addCRDs(repo, operator, outputDir, branch, preservedFiles=None, overwrite=Fa
         preservedFiles (list, optional): List of files to preserve. Defaults to None.
         overwrite (bool, optional): Whether to overwrite existing files. Defaults to False.
 
+    Returns:
+        list: Filenames that could not be parsed as YAML and were skipped.
+        Empty if every file was scanned successfully. This is informational
+        only — it is not treated as a fatal error by this function or its
+        caller.
+
     Raises:
         ValueError: If bundlePath is not found or if CRD file copying fails.
     """
     logging.info("Adding Custom Resource Definitions (CRDs) for operator: %s", operator['name'])
+
+    skipped_files = []
 
     if 'bundlePath' in operator:
         manifestsPath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp", repo, operator["bundlePath"])
@@ -1520,13 +1544,30 @@ def addCRDs(repo, operator, outputDir, branch, preservedFiles=None, overwrite=Fa
 
         filepath = os.path.join(manifestsPath, filename)
         with open(filepath, 'r', encoding='utf-8') as f:
+            raw_content = f.read()
+
+        try:
             # Handle multi-document YAML files for ACM 2.16+, MCE 2.11+
             if is_version_compatible(branch, '2.16', '2.11', '2.16'):
-                docs = list(yaml.safe_load_all(f))
+                docs = list(yaml.safe_load_all(raw_content))
             else:
                 # Fallback to single-document for older versions
-                single_doc = yaml.safe_load(f)
+                single_doc = yaml.safe_load(raw_content)
                 docs = [single_doc] if single_doc else []
+        except yaml.YAMLError as e:
+            hint = (
+                "file appears to contain Go/Helm template syntax ('{{ }}'), "
+                "which is not valid standalone YAML"
+                if "{{" in raw_content
+                else "file is not valid YAML"
+            )
+            logging.warning(
+                "UNPARSEABLE_MANIFEST: Skipped '%s' for operator '%s' while scanning for "
+                "CRDs — %s. Error: %s",
+                filename, operator['name'], hint, e,
+            )
+            skipped_files.append(filename)
+            continue
 
         # Check each document for CRDs
         for doc in docs:
@@ -1540,7 +1581,14 @@ def addCRDs(repo, operator, outputDir, branch, preservedFiles=None, overwrite=Fa
                     logging.info("CRD file copied: %s", filename)
                 break  # Only copy the file once even if it has multiple CRDs
 
+    if skipped_files:
+        logging.warning(
+            "CRD scan for operator '%s' skipped %d unparseable file(s): %s",
+            operator['name'], len(skipped_files), ", ".join(skipped_files),
+        )
+
     logging.info("CRDs added successfully for operator: %s", operator['name'])
+    return skipped_files
 
 def getBundleManifestsPath(repo, operator):
     """

--- a/scripts/bundle-generation/generate-charts.py
+++ b/scripts/bundle-generation/generate-charts.py
@@ -1758,7 +1758,6 @@ def main():
     for repo in components:
         repo_name = repo.get("repo_name")
 
-        logging.info("Cloning: %s", repo_name)
         repo_path = os.path.join(SCRIPT_DIR, "tmp", repo_name)
 
         if os.path.exists(repo_path): # If path exists, remove and re-clone
@@ -1768,20 +1767,27 @@ def main():
         if repo_name in component_fork_overrides:
             git_url = component_fork_overrides[repo_name]
             logging.info(f"Using fork override for {repo_name}: {git_url}")
-            repository = Repo.clone_from(git_url, repo_path)
         else:
-            repository = Repo.clone_from(repo["github_ref"], repo_path) # Clone repo to above path
+            git_url = repo["github_ref"]
 
         # Check for branch override first, then use config branch, or default to empty string
         if repo_name in component_branch_overrides:
             branch = component_branch_overrides[repo_name]
             logging.info(f"Using branch override for {repo_name}: {branch}")
-            repository.git.checkout(branch)
         elif 'branch' in repo:
             branch = repo['branch']
-            repository.git.checkout(branch) # If a branch is specified, checkout that branch
         else:
             branch = ""
+
+        # Shallow, single-branch clone: only the tip commit of the target
+        # branch is needed, since this script only reads current file
+        # contents and never inspects history. Fall back to a shallow clone
+        # of the repository's default branch if none was specified.
+        logging.info("Cloning: %s (branch=%s)", repo_name, branch or "<default>")
+        if branch:
+            Repo.clone_from(git_url, repo_path, branch=branch, depth=1)
+        else:
+            Repo.clone_from(git_url, repo_path, depth=1)
         
         # Loop through each operator in the repo identified by the config
         for chart in repo["charts"]:

--- a/scripts/bundle-generation/move-charts.py
+++ b/scripts/bundle-generation/move-charts.py
@@ -348,15 +348,21 @@ def main():
 
     # Loop through each repo in the config.yaml
     for repo in components:
-        logging.info("Cloning: %s", repo["repo_name"])
         repo_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp/" + repo["repo_name"]) # Path to clone repo to
         if os.path.exists(repo_path): # If path exists, remove and re-clone
             shutil.rmtree(repo_path)
 
-        repository = Repo.clone_from(repo["github_ref"], repo_path) # Clone repo to above path
         branch = repo.get('branch', 'main')  # Default to 'main' if no branch specified
+
+        # Shallow, single-branch clone: only the tip commit of the target
+        # branch is needed, since this script only reads current file
+        # contents and never inspects history. Fall back to a shallow clone
+        # of the repository's default branch if none was specified.
+        logging.info("Cloning: %s (branch=%s)", repo["repo_name"], repo.get('branch', '<default>'))
         if 'branch' in repo:
-            repository.git.checkout(repo['branch']) # If a branch is specified, checkout that branch
+            Repo.clone_from(repo["github_ref"], repo_path, branch=repo['branch'], depth=1) # Clone repo to above path
+        else:
+            Repo.clone_from(repo["github_ref"], repo_path, depth=1) # Clone repo to above path
 
         # Loop through each operator in the repo identified by the config
         for chart in repo["charts"]:


### PR DESCRIPTION
# Description

Two related fixes to the bundle-generation scripts: stop the whole tool crashing when a single bundle manifest can't be parsed as plain YAML, and stop doing full (unbounded-history) git clones for every component repo processed.

## Related Issue

Found while investigating a failing `stolostron/multiclusterhub-operator` scheduled workflow run (run 31521675972): `addCRDs()` crashed with an uncaught `yaml.parser.ParserError` on a bundle manifest (`networkpolicy.yaml` in `multicloud-operators-subscription`) that embeds Helm/Go template syntax, which killed chart regeneration for every other component in the same run. Companion shallow-clone changes are also being made in `stolostron/multiclusterhub-operator` (stolostron/multiclusterhub-operator#4579) and `stolostron/backplane-operator` (stolostron/backplane-operator#3835), which each vendor a copy of `generate-shell.py` that clones this repo.

## Changes Made

1. **`addCRDs()` resilience** (`bundles-to-charts.py`): wraps the per-file YAML parse in `try/except yaml.YAMLError`, mirroring the existing pattern already used in `find_templates_of_type()` for the same kind of directory scan. A file that fails to parse is now logged with an `UNPARSEABLE_MANIFEST:` prefix (so callers can grep for exactly this condition instead of every routine `WARNING` the script already emits) and skipped, rather than crashing the whole run. This is intentionally non-fatal — it's not added to any error list that would fail the run — since a single malformed file in one upstream repo shouldn't block chart generation for every other component being processed in the same invocation.
2. **Shallow, single-branch clones** (`bundles-to-charts.py`, `generate-charts.py`, `move-charts.py`): each of these clones every component repo with `Repo.clone_from(url, path)` (full history, every branch) and then separately checks out the target branch. None of these scripts read anything beyond current file contents on one branch (no git log/blame/diff-against-history usage anywhere in the codebase). Resolved the target branch before cloning and pass `branch=`/`depth=1` to `clone_from()` directly, dropping the now-redundant separate checkout call.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Verified end-to-end against the real failure condition: pointed a scratch `multiclusterhub-operator` checkout's `hack/bundle-automation/config.yaml` at a fork branch of `multicloud-operators-subscription` still containing the original, unmodified `networkpolicy.yaml` (with the Helm template syntax intact), and ran `generate-shell.py --update-charts-from-bundles` against this patched branch.

- Before this fix: uncaught `yaml.parser.ParserError`, exit code 2, entire run fails.
- After this fix: exit code 0, "All repositories and operators processed successfully," every other component's chart still generated correctly, and the skipped file is clearly flagged: `UNPARSEABLE_MANIFEST: Skipped 'networkpolicy.yaml' for operator 'multicloud-operators-subscription' while scanning for CRDs — file appears to contain Go/Helm template syntax ('{{ }}'), which is not valid standalone YAML.`
- Grepping the full run log for `WARNING` case-insensitively matches 81 lines (mostly routine, expected output); grepping for `UNPARSEABLE_MANIFEST` matches exactly the 1 line that's actually actionable.
- For the shallow-clone change: as a concrete before/after, cloning a component repo with a long release history dropped from a 6.2M `.git` directory (full clone) to 992K (shallow, single-branch), with no other code depending on git history for these repos.
- All three modified Python files pass `python3 -m py_compile`.

## Reviewers

/cc @cameronmwall @ngraham20 @gparvin @msmigiel-rh

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bundle generation now continues when individual YAML manifests cannot be parsed, while recording skipped files for review.
  * CRD detection continues to support manifests containing multiple documents.

* **Improvements**
  * Repository processing now supports selecting configured or overridden branches during cloning.
  * Cloning uses shallow, single-branch downloads to reduce processing time and storage requirements.
  * Logs now show the selected repository branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

