### PR TITLE
chore: remove retired approver/reviewer from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,9 @@
 approvers:
 - cameronmwall
 - dislbenn
-- joeg-pro
 - ngraham20
 
 reviewers:
 - cameronmwall
 - dislbenn
-- joeg-pro
 - ngraham20


### PR DESCRIPTION
# Description

Removes `joeg-pro` from the `approvers` and `reviewers` lists in `OWNERS` since they've retired.

## Related Issue

N/A

## Changes Made

Removed `joeg-pro` from both lists in `OWNERS`. No other changes.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

N/A

## Reviewers

/cc @cameronmwall @ngraham20 @gparvin @msmigiel-rh

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
